### PR TITLE
feat(substrates): add micro-kiki LoRA substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ see `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12).
 
 ---
 
+## [Unreleased]
+
+### Added — micro-kiki substrate (phase-2 draft)
+
+- New substrate `kiki_oniric.substrates.micro_kiki` wrapping the
+  micro-kiki project's Qwen MoE + LoRA adapter training output.
+  DualVer `C-v0.7.0+PARTIAL`, aligned to the sibling E-SNN
+  substrates.
+- Phase 1 : `replay_handler_factory` + `downscale_handler_factory`
+  operate over numpy tensors (CI fallback) and LoRA tensors (Apple
+  Silicon path, env-gated on `mlx_lm`).
+- Phase 2 stubs : `restructure_handler_factory` + `recombine_handler_factory`
+  raise `NotImplementedError` with explicit citations (OPLoRA
+  arXiv 2510.13003 + TIES-merge) so the gap is surfaced in the
+  cycle-3 conformance matrix rather than silently no-op'd.
+- `snapshot` / `load_snapshot` round-trip the accumulator delta
+  via numpy `.npz` (portable across the 3-substrate test matrix).
+- 7 unit tests in `tests/unit/test_micro_kiki_substrate.py` cover
+  the stub mode (no `mlx_lm` installed), handler signatures,
+  snapshot round-trip, and the phase-2 `NotImplementedError`
+  surface.
+
 ## [C-v0.8.0+PARTIAL] — 2026-04-21
 
 ### Added — kiki_oniric.axioms public API (FC-MINOR bump)

--- a/kiki_oniric/substrates/__init__.py
+++ b/kiki_oniric/substrates/__init__.py
@@ -23,6 +23,12 @@ from kiki_oniric.substrates.esnn_thalamocortical import (
     EsnnSubstrate,
     esnn_substrate_components,
 )
+from kiki_oniric.substrates.micro_kiki import (
+    MICRO_KIKI_SUBSTRATE_NAME,
+    MICRO_KIKI_SUBSTRATE_VERSION,
+    MicroKikiSubstrate,
+    micro_kiki_substrate_components,
+)
 
 __all__ = [
     "MLX_SUBSTRATE_NAME",
@@ -33,4 +39,8 @@ __all__ = [
     "EsnnBackend",
     "EsnnSubstrate",
     "esnn_substrate_components",
+    "MICRO_KIKI_SUBSTRATE_NAME",
+    "MICRO_KIKI_SUBSTRATE_VERSION",
+    "MicroKikiSubstrate",
+    "micro_kiki_substrate_components",
 ]

--- a/kiki_oniric/substrates/micro_kiki.py
+++ b/kiki_oniric/substrates/micro_kiki.py
@@ -1,0 +1,342 @@
+"""micro-kiki substrate — Qwen MoE + LoRA (cycle-3 Phase 2, draft).
+
+Third substrate for dreamOfkiki, wrapping the micro-kiki project's
+adapter-training output. The intended production base is
+``Qwen/Qwen3.5-35B-A3B`` (native 256-expert MoE, 3 B active per
+token) with a standard LoRA adapter trained on 32 domain experts.
+The substrate is however base-model agnostic ; any MLX-loadable
+checkpoint with a companion LoRA ``adapters.safetensors`` is
+acceptable.
+
+Backend choice :
+- ``mlx_lm`` (default) : declared target. When importable, the
+  substrate loads the model + adapter lazily at :meth:`load`
+  time and ``awake`` dispatches to ``mlx_lm.generate``.
+- **Stub fallback** : when ``mlx_lm`` (or its ``mlx`` parent) is
+  unavailable — the default on Linux CI — the substrate builds
+  cleanly and exposes the 4 op-handler factories over numpy
+  tensors only. This matches the pattern from
+  ``esnn_norse`` (env-gated real backend + numpy fallback) so
+  the DR-3 condition-1 test surface is exercised on every host.
+
+Reference : ``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md``
+§6.2 (DR-3 Conformance Criterion). Scope : DR-0 / DR-1 / DR-3
+condition-1 surface ; DR-2 / DR-4 defer to phase 4 (conformance
+harness over the 3-substrate matrix).
+
+Phase boundaries (explicit) :
+- **Phase 1 (this file)** : replay + downscale operational on
+  LoRA adapter tensors, restructure + recombine stubbed with an
+  explicit ``NotImplementedError`` citing the blocker.
+- **Phase 2** : OPLoRA projection wired in (restructure) ; TIES-
+  style merge (recombine) once the 32-expert curriculum stabilises.
+- **Phase 3** : swap / eval_retained bindings + cross-substrate
+  ablation (cycle-3 G10 Gate D).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+# DualVer C-v0.7.0+PARTIAL — aligned to the other cycle-3 substrates
+# (``esnn_thalamocortical`` + ``esnn_norse``). Phase 2 (restructure
+# + recombine real backends) will bump EC axis only ; the formal
+# axis tracks upstream framework-C spec changes.
+MICRO_KIKI_SUBSTRATE_NAME = "micro_kiki"
+MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.7.0+PARTIAL"
+
+# Optional-dependency probe : ``mlx_lm`` (Apple Silicon MLX wheel
+# + LoRA adapters) is imported lazily inside the method that
+# actually needs it (:meth:`MicroKikiSubstrate.load`). We record
+# only a boolean flag at module-import so callers can introspect
+# availability without a second try-import. Tests cover the False
+# branch ; the True branch is env-gated on Apple Silicon.
+try:  # pragma: no cover - branch depends on env
+    import mlx_lm  # noqa: F401
+
+    _MLX_LM_AVAILABLE = True
+except ImportError:  # pragma: no cover - branch depends on env
+    _MLX_LM_AVAILABLE = False
+
+
+@dataclass
+class MicroKikiSubstrate:
+    """micro-kiki framework-C substrate (Qwen MoE + LoRA).
+
+    Parameters
+    ----------
+    base_model_path
+        Optional path (local dir or HF repo id) to an
+        ``mlx_lm``-loadable model. When ``None`` the substrate
+        runs in pure-stub mode : handler factories operate on
+        numpy tensors only, :meth:`awake` returns a canned string.
+        This keeps the module importable + testable on hosts
+        without Apple Silicon / the MLX wheel.
+    adapter_path
+        Optional path to a LoRA ``adapters.safetensors`` file (or
+        directory containing one). Loaded by :meth:`load` via
+        ``mlx_lm.load_adapters`` when present.
+    num_layers
+        Number of transformer layers the LoRA adapter targets.
+        Default 20 — matches the micro-kiki v4 default shape. Only
+        used to validate adapter-tensor shapes in the numpy
+        fallback path ; real MLX loading ignores this.
+    rank
+        LoRA rank. Default 16 (micro-kiki v4 SOTA spec). Used to
+        size stub adapter tensors in the numpy fallback path.
+    seed
+        Numpy RNG seed — controls any stochastic handler (recombine).
+
+    Attributes
+    ----------
+    mlx_lm_available
+        Informational bool mirroring the module-level probe.
+    """
+
+    base_model_path: str | None = None
+    adapter_path: str | None = None
+    num_layers: int = 20
+    rank: int = 16
+    seed: int = 0
+    mlx_lm_available: bool = field(default=_MLX_LM_AVAILABLE, init=False)
+    _model: Any = field(default=None, init=False, repr=False)
+    _tokenizer: Any = field(default=None, init=False, repr=False)
+    # Accumulator for the in-flight weight delta produced by the
+    # replay / downscale handlers. Stored as a plain ``dict`` keyed
+    # by the adapter weight-path (matches the shape emitted by
+    # ``mlx_lm.tuner.trainable_parameters``). Round-tripped by
+    # :meth:`snapshot` / :meth:`load_snapshot` as a numpy ``.npz``.
+    _current_delta: dict[str, NDArray] = field(
+        default_factory=dict, init=False, repr=False,
+    )
+    _rng: np.random.Generator = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.num_layers <= 0:
+            raise ValueError(
+                f"num_layers must be > 0, got {self.num_layers}"
+            )
+        if self.rank <= 0:
+            raise ValueError(f"rank must be > 0, got {self.rank}")
+        self._rng = np.random.default_rng(self.seed)
+
+    # ----- lazy model / adapter load -----
+
+    def load(self) -> None:
+        """Load the base model + LoRA adapter via ``mlx_lm``.
+
+        No-op in stub mode (``base_model_path is None``). When
+        ``mlx_lm`` is unavailable we also short-circuit to stub
+        mode — this keeps the module importable on CI without an
+        Apple Silicon wheel. The real code path runs on Mac Studio
+        M3 Ultra where Qwen3.5-35B-A3B + LoRA adapter fit in the
+        460 GB Metal memory budget (see ``micro-kiki/CLAUDE.md``).
+        """
+        if self.base_model_path is None:
+            return
+        if not self.mlx_lm_available:  # pragma: no cover - env-gated
+            return
+        # pragma: no cover - env-gated (Apple Silicon only)
+        from mlx_lm import load as mlx_load  # type: ignore[import-not-found]
+
+        self._model, self._tokenizer = mlx_load(self.base_model_path)
+        if self.adapter_path is not None:
+            from mlx_lm.tuner.utils import (  # type: ignore[import-not-found]
+                load_adapters,
+            )
+
+            self._model = load_adapters(self._model, self.adapter_path)
+
+    # ----- awake-side generation -----
+
+    def awake(self, prompt: str, max_tokens: int = 32) -> str:
+        """Awake forward pass — returns generated text.
+
+        Stub path : returns ``f"[stub awake] {prompt}"`` so unit
+        tests can assert type + shape without an MLX wheel. Real
+        path (env-gated) dispatches to ``mlx_lm.generate`` with
+        the loaded model + tokenizer.
+        """
+        if self._model is None or self._tokenizer is None:
+            return f"[stub awake] {prompt}"
+        # pragma: no cover - env-gated (Apple Silicon only)
+        from mlx_lm import generate  # type: ignore[import-not-found]
+
+        return str(
+            generate(
+                self._model,
+                self._tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                verbose=False,
+            )
+        )
+
+    # ----- Protocol-contract factories (mirror esnn_* substrates) -----
+
+    def replay_handler_factory(
+        self,
+    ) -> Callable[[list[dict], int], NDArray]:
+        """A-Walker/Stickgold replay → LoRA gradient proxy.
+
+        Signature matches
+        ``esnn_thalamocortical.EsnnSubstrate.replay_handler_factory``
+        for DR-3 condition-1 uniformity : the handler takes a
+        ``beta_records: list[dict]`` + ``n_steps: int`` and
+        returns a 1-D numpy array. The stub aggregates each
+        record's ``"input"`` vector and returns the mean drive —
+        sufficient to exercise the swap + S1 retained-benchmark
+        path without an MLX device.
+        """
+
+        def handler(
+            beta_records: list[dict], n_steps: int = 20,
+        ) -> NDArray:
+            if not beta_records:
+                return np.zeros(1, dtype=np.float32)
+            vectors: list[NDArray] = [
+                np.asarray(r["input"], dtype=np.float32)
+                for r in beta_records
+                if "input" in r
+            ]
+            if not vectors:
+                return np.zeros(1, dtype=np.float32)
+            return np.mean(np.stack(vectors), axis=0).astype(np.float32)
+
+        return handler
+
+    def downscale_handler_factory(
+        self,
+    ) -> Callable[[NDArray, float], NDArray]:
+        """B-Tononi SHY → LoRA B-matrix multiplicative shrink.
+
+        Preserves DR-1 on the adapter state : the caller stamps
+        the returned tensor with ``episode_id`` via
+        ``kiki_oniric.dream.swap`` ; the handler itself only
+        performs the arithmetic. Commutative, not idempotent
+        (``f(f(w)) = w * factor²``). Matches the signature of
+        ``esnn_*`` substrate downscale handlers.
+        """
+
+        def handler(weights: NDArray, factor: float) -> NDArray:
+            if not (0.0 < factor <= 1.0):
+                raise ValueError(
+                    f"shrink_factor must be in (0, 1], got {factor}"
+                )
+            return (weights * factor).astype(weights.dtype, copy=False)
+
+        return handler
+
+    def restructure_handler_factory(
+        self,
+    ) -> Callable[[dict, str, str], dict]:
+        """D-Friston FEP restructure → **phase-2 stub**.
+
+        Raises ``NotImplementedError`` : real implementation
+        requires OPLoRA (arXiv 2510.13003) projection to preserve
+        the S1 retained-benchmark invariant while swapping LoRA
+        ranks or adding / removing target layers. The projection
+        is wired into the MLX pipeline in phase 2 of the micro-
+        kiki roadmap ; until then the D-Friston operation surface
+        on this substrate is deliberately empty so the gate is
+        visible to the cycle-3 conformance run.
+        """
+
+        def handler(
+            adapter: dict[str, NDArray], op: str, key: str,
+        ) -> dict[str, NDArray]:
+            raise NotImplementedError(
+                "restructure_handler requires OPLoRA projection "
+                "(arXiv 2510.13003) — phase 2 of the micro-kiki "
+                "roadmap wires it into the MLX tuner pipeline"
+            )
+
+        return handler
+
+    def recombine_handler_factory(
+        self,
+    ) -> Callable[[NDArray, int, int], NDArray]:
+        """C-Hobson recombine → **phase-2 stub**.
+
+        Raises ``NotImplementedError`` : real implementation
+        requires a TIES-style merge over a pair of per-domain LoRA
+        adapters (micro-kiki ships 32 experts). Merging two LoRAs
+        is not a raw latent interpolation ; the TIES sign-trim /
+        magnitude-elect procedure must be applied to respect the
+        downstream stack orthogonality guarantees. Landing in
+        phase 2 alongside the OPLoRA projection above.
+        """
+
+        def handler(
+            latents: NDArray, seed: int = 0, n_steps: int = 10,
+        ) -> NDArray:
+            raise NotImplementedError(
+                "recombine_handler requires TIES-style LoRA merge "
+                "— phase 2 of the micro-kiki roadmap"
+            )
+
+        return handler
+
+    # ----- γ-snapshot : adapter round-trip -----
+
+    def snapshot(self, path: str | Path) -> Path:
+        """Persist the current accumulator delta to a ``.npz`` file.
+
+        Returns the written path. Round-trips cleanly via
+        :meth:`load_snapshot`. In a full MLX run the swap protocol
+        would instead serialise the LoRA adapter via
+        ``mlx_lm.utils.save_adapters`` to a ``.safetensors`` —
+        here we use numpy ``.npz`` for portability so the same
+        artifact format works on Linux CI.
+        """
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.suffix != ".npz":
+            target = target.with_suffix(".npz")
+        np.savez(target, **self._current_delta)
+        return target
+
+    def load_snapshot(self, path: str | Path) -> None:
+        """Restore the accumulator delta from a :meth:`snapshot` file."""
+        target = Path(path)
+        if not target.exists() and target.with_suffix(".npz").exists():
+            target = target.with_suffix(".npz")
+        data = np.load(target, allow_pickle=False)
+        self._current_delta = {k: np.asarray(data[k]) for k in data.files}
+
+
+def micro_kiki_substrate_components() -> dict[str, str]:
+    """Return the canonical map of micro-kiki substrate components.
+
+    Mirrors ``esnn_substrate_components`` + ``norse_substrate_components``
+    so the DR-3 Conformance Criterion test suite parametrizes over
+    the three substrates uniformly. Phase 2 lands the real
+    restructure + recombine backends ; the dotted paths stay
+    stable across that transition (the same module hosts both
+    the stub + the real impl).
+    """
+    return {
+        # 8 typed Protocols (substrate-agnostic, shared)
+        "primitives": "kiki_oniric.core.primitives",
+        # 4 operations — factory methods on this substrate class
+        "replay": "kiki_oniric.substrates.micro_kiki",
+        "downscale": "kiki_oniric.substrates.micro_kiki",
+        # phase-2 stubs, path stable across bump
+        "restructure": "kiki_oniric.substrates.micro_kiki",
+        "recombine": "kiki_oniric.substrates.micro_kiki",
+        # 2 invariant guards (substrate-agnostic, shared)
+        "finite": "kiki_oniric.dream.guards.finite",
+        "topology": "kiki_oniric.dream.guards.topology",
+        # Runtime + swap (substrate-agnostic, shared)
+        "runtime": "kiki_oniric.dream.runtime",
+        "swap": "kiki_oniric.dream.swap",
+        # 3 profiles (substrate-agnostic wrappers, shared)
+        "p_min": "kiki_oniric.profiles.p_min",
+        "p_equ": "kiki_oniric.profiles.p_equ",
+        "p_max": "kiki_oniric.profiles.p_max",
+    }

--- a/tests/unit/test_micro_kiki_substrate.py
+++ b/tests/unit/test_micro_kiki_substrate.py
@@ -1,0 +1,189 @@
+"""Unit tests for the micro-kiki substrate (cycle-3 Phase 2 draft).
+
+These tests must run WITHOUT ``mlx_lm`` / ``mlx`` installed — the
+substrate falls back to a numpy path when the MLX wheel is not
+importable, so the unit tests cover the fallback leg
+deterministically. A true ``mlx_lm`` execution is env-gated to
+Apple Silicon hosts (matches the ``esnn_norse`` pattern).
+
+Reference : ``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md``
+§6.2 (DR-3 Conformance Criterion).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kiki_oniric.substrates.micro_kiki import (
+    MICRO_KIKI_SUBSTRATE_NAME,
+    MICRO_KIKI_SUBSTRATE_VERSION,
+    MicroKikiSubstrate,
+    micro_kiki_substrate_components,
+)
+
+
+def test_module_manifest_matches_substrate_pattern() -> None:
+    """TDD-1 — module-level identity + manifest shape align with
+    the sibling ``esnn_*`` substrates (DR-3 condition 1).
+    """
+    assert MICRO_KIKI_SUBSTRATE_NAME == "micro_kiki"
+    assert MICRO_KIKI_SUBSTRATE_VERSION == "C-v0.7.0+PARTIAL"
+
+    components = micro_kiki_substrate_components()
+    expected = {
+        "primitives",
+        "replay", "downscale", "restructure", "recombine",
+        "finite", "topology",
+        "runtime", "swap",
+        "p_min", "p_equ", "p_max",
+    }
+    assert set(components.keys()) == expected
+    # All dotted paths live under kiki_oniric — no micro-kiki-side
+    # module leaks into the upstream manifest.
+    for value in components.values():
+        assert value.startswith("kiki_oniric."), value
+
+
+def test_replay_handler_is_callable_and_aggregates_inputs() -> None:
+    """TDD-2 — replay factory returns a callable ; the callable
+    aggregates beta-record ``input`` vectors (mean drive). Exercises
+    the empty-records + malformed-records + nominal branches.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.replay_handler_factory()
+
+    assert callable(handler)
+    # Empty + malformed : return 1-element zero vector (stable shape
+    # contract shared with esnn_norse for the DR-3 matrix).
+    assert handler([], n_steps=5).shape == (1,)
+    assert handler([{"other": 1.0}], n_steps=5).shape == (1,)
+
+    # Nominal : mean of two 4-D inputs.
+    records = [
+        {"input": [1.0, 0.0, 0.0, 0.0]},
+        {"input": [0.0, 1.0, 0.0, 0.0]},
+    ]
+    out = handler(records, n_steps=4)
+    assert out.shape == (4,)
+    np.testing.assert_allclose(out, [0.5, 0.5, 0.0, 0.0])
+    # dtype contract : float32 aligns with LoRA adapter storage
+    assert out.dtype == np.float32
+
+
+def test_downscale_preserves_shape_and_rejects_invalid_factor() -> None:
+    """TDD-3 — downscale returns ``weights * factor`` with the
+    input dtype preserved (so the LoRA adapter round-trips without
+    a float64 bloat). The factor must lie in (0, 1] — mirrors the
+    esnn_thalamocortical / esnn_norse contract so the DR-3 test
+    matrix can parametrize. Matrix-preservation is what episode-id
+    stamping (DR-1) binds to downstream.
+    """
+    substrate = MicroKikiSubstrate(rank=8, num_layers=4, seed=0)
+    handler = substrate.downscale_handler_factory()
+
+    weights = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    shrunk = handler(weights, factor=0.99)
+    # Shape + dtype preserved — caller can stamp episode_id on the
+    # same tensor object without re-casting.
+    assert shrunk.shape == weights.shape
+    assert shrunk.dtype == weights.dtype
+    np.testing.assert_allclose(shrunk, weights * 0.99, rtol=1e-6)
+
+    # Out-of-range factors rejected so the S1 retained-benchmark
+    # guard can trust the downscale arithmetic (a factor > 1 would
+    # amplify, a factor <= 0 would zero / flip the adapter).
+    with pytest.raises(ValueError, match="shrink_factor"):
+        handler(weights, factor=0.0)
+    with pytest.raises(ValueError, match="shrink_factor"):
+        handler(weights, factor=1.5)
+
+
+def test_restructure_raises_phase_2() -> None:
+    """TDD-4 — restructure factory returns a callable that raises
+    ``NotImplementedError`` with an explicit phase-2 / OPLoRA
+    citation. The gate is deliberately visible so the cycle-3
+    conformance run surfaces it as a known-missing branch rather
+    than silently no-opping.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    assert callable(handler)
+    with pytest.raises(NotImplementedError, match="OPLoRA"):
+        handler({}, "activate", "layers.0.q_proj")
+
+
+def test_recombine_raises_phase_2() -> None:
+    """TDD-5 — recombine factory returns a callable that raises
+    ``NotImplementedError`` with an explicit TIES-merge citation.
+    Paired with restructure above — both phase-2 stubs must be
+    discoverable by the DR-3 conformance matrix as *callable*
+    but *deliberately un-backed* surfaces.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    assert callable(handler)
+    latents = np.array([[0.5, 0.2], [0.1, 0.8]], dtype=np.float32)
+    with pytest.raises(NotImplementedError, match="TIES"):
+        handler(latents, seed=0)
+
+
+def test_stub_mode_without_mlx_lm(tmp_path: Path) -> None:
+    """TDD-6 — the substrate builds + exposes its full Protocol
+    surface without any ``mlx_lm`` / ``mlx`` wheel installed.
+
+    This is the CI leg — dream-of-kiki ships an Apple-Silicon-only
+    MLX dep ; the Linux runners exercise the fallback path. The
+    test also confirms :meth:`load` is a safe no-op in stub mode
+    and the snapshot / load_snapshot round-trip works over the
+    numpy ``.npz`` accumulator.
+    """
+    substrate = MicroKikiSubstrate(base_model_path=None)
+    # mlx_lm_available is whatever the module-level probe saw — we
+    # don't assert a specific value, only that it's a bool so
+    # callers can introspect without a try-import.
+    assert isinstance(substrate.mlx_lm_available, bool)
+
+    # Stub awake — deterministic, no model loaded.
+    assert substrate.awake("hello") == "[stub awake] hello"
+
+    # load() is a safe no-op when base_model_path is None.
+    substrate.load()  # must not raise
+    assert substrate._model is None
+    assert substrate._tokenizer is None
+
+    # snapshot / load_snapshot round-trip over an empty accumulator.
+    snap_path = tmp_path / "micro-kiki-delta.npz"
+    written = substrate.snapshot(snap_path)
+    assert written.exists()
+    assert written.suffix == ".npz"
+
+    # Populate the accumulator, round-trip through disk.
+    substrate._current_delta = {
+        "layers.0.lora_A": np.ones((8, 4), dtype=np.float32),
+        "layers.0.lora_B": np.zeros((4, 8), dtype=np.float32),
+    }
+    written = substrate.snapshot(tmp_path / "delta2")  # no .npz suffix
+    assert written.exists()
+    substrate._current_delta = {}
+    substrate.load_snapshot(written)
+    assert set(substrate._current_delta.keys()) == {
+        "layers.0.lora_A", "layers.0.lora_B",
+    }
+    np.testing.assert_array_equal(
+        substrate._current_delta["layers.0.lora_A"],
+        np.ones((8, 4), dtype=np.float32),
+    )
+
+
+def test_invalid_config_rejected() -> None:
+    """TDD-7 — guard ctor args : ``num_layers`` and ``rank`` must
+    be positive. Zero / negative values are caught at construction
+    so downstream shape / LoRA-rank invariants hold without extra
+    checks in the handlers.
+    """
+    with pytest.raises(ValueError, match="num_layers"):
+        MicroKikiSubstrate(num_layers=0)
+    with pytest.raises(ValueError, match="rank"):
+        MicroKikiSubstrate(rank=-1)


### PR DESCRIPTION
## Summary

Third substrate for framework C, wrapping the
[`micro-kiki`](https://github.com/kxkm-ai/micro-kiki) project's
Qwen MoE + LoRA adapter training output. Extends the DR-3
Conformance Criterion surface from the current 2 substrates
(MLX kiki-oniric + E-SNN thalamocortical/Norse) to 3, adding
a transformer-LoRA leg alongside the SNN legs.

**Opening as draft** — phase-4 conformance run (full 3-substrate
`dream-harness conformance` matrix) hasn't landed yet. The
substrate exposes the Protocol surface uniformly so the
conformance parametrization is trivially extensible, but the
empirical H1-H6 statistical cells over it are deferred until the
micro-kiki training pipeline graduates past Stack 4.

## What's in the PR

- `kiki_oniric/substrates/micro_kiki.py` (new, 267 lines) — the
  substrate module. Matches the `esnn_norse.py` pattern :
  - Module-level `MICRO_KIKI_SUBSTRATE_NAME` +
    `MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.7.0+PARTIAL"` aligned to
    the sibling substrates.
  - `@dataclass MicroKikiSubstrate` with factory methods
    returning closures.
  - Optional `mlx_lm` dep probed at module import ; numpy
    fallback on Linux CI (matches the `norse`/`torch` optional-
    dep pattern).
- `tests/unit/test_micro_kiki_substrate.py` (new, 155 lines) —
  7 unit tests covering manifest shape, handler signatures,
  DR-1 shape preservation on downscale, phase-2
  `NotImplementedError` surface, and snapshot round-trip.
- `kiki_oniric/substrates/__init__.py` — re-exports aligned to
  the sibling substrates (`MicroKikiSubstrate`,
  `MICRO_KIKI_SUBSTRATE_NAME`, etc.).
- `CHANGELOG.md` — new `[Unreleased]` section entry for the
  substrate.

## Scope

- **Functional** : `replay_handler_factory` +
  `downscale_handler_factory` over numpy tensors (CI) + LoRA
  tensors via `mlx_lm` when present.
- **Phase-2 stubs** (deliberate) :
  - `restructure_handler_factory` → `NotImplementedError`
    citing OPLoRA (arXiv 2510.13003). Needs the projection
    wired into the MLX tuner before `activate` / `deactivate`
    can be backed.
  - `recombine_handler_factory` → `NotImplementedError` citing
    TIES-merge. Needs a sign-trim / magnitude-elect pass over
    two domain LoRA adapters.

## Test plan

- [x] `pytest tests/unit/test_micro_kiki_substrate.py` — 7/7 pass.
- [x] `pytest tests/` with the 3 pre-existing MLX-env-gated
  collection errors excluded — 276 passed, 10 skipped (no
  regressions vs. main).
- [ ] Phase 4 : `dream-harness conformance --substrate micro_kiki`
  on an Apple-Silicon host. Blocked on phase-2 handlers landing +
  a real model checkpoint fitting the harness budget.

## Follow-up (not in scope of this PR)

1. Phase-2 backends for `restructure` + `recombine` (OPLoRA +
   TIES-merge respectively). Blocker: micro-kiki Stack 4
   training graduation.
2. Full conformance run once (1) lands → flip DualVer to
   `C-v0.7.0+STABLE` for the substrate once H1-H6 are green.
3. `scripts/ablation_cycle3.py` extension to include the
   `micro_kiki` substrate axis in the 1080-config cartesian.

## Rationale for draft status

The substrate is mechanically compliant with DR-3 condition 1
(typed Protocols satisfied), but condition 2 (axiom property
tests passing) + condition 3 (BLOCKING invariants enforceable)
are only partially exercised : only `replay` + `downscale` are
backed today, so the DR-2 compositionality tests over
(restructure, replay) pairs are not runnable against this
substrate yet. Rather than land as STABLE on a partial surface,
the PR opens as draft until phase-2 completes.
