### PR TITLE
micro_kiki: OPLoRA restructure handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ see `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12).
   snapshot round-trip, and the phase-2 `NotImplementedError`
   surface.
 
+### Added — micro-kiki substrate: OPLoRA restructure wired (phase-2)
+
+- `micro_kiki` substrate: OPLoRA (arXiv 2510.13003, Du et al.) wired
+  into `restructure_handler_factory`; projects new adapter deltas
+  onto the orthogonal complement of the prior subspace via numpy
+  SVD. Replaces the phase-1 `NotImplementedError` stub.
+- New `_oplora_projector(prior_deltas, rank_thresh=1e-4) -> ndarray`
+  module-level helper. Guards: empty priors reject (caller handles
+  no-op leg via handler), shape-mismatch across priors raises,
+  rank collapse falls back to identity projector with a warning.
+- New `MicroKikiRestructureState` dataclass exposed read-only via
+  `MicroKikiSubstrate.restructure_state`, records DR-0 completion
+  flag + operation label and DR-1 `episode_id` stamps.
+- 9 new unit tests in `tests/unit/test_micro_kiki_restructure.py`
+  cover projector algebra (orthogonality, idempotence, symmetry,
+  rank-collapse fallback, shape-mismatch guard) and handler
+  contract (DR-0 counters, DR-1 stamping, op-vocabulary guard,
+  missing-key guard, projector shape guard). `test_micro_kiki_substrate`
+  retires the phase-1 `NotImplementedError` gate in favour of an
+  OPLoRA-wired assertion.
+- Phase-2 `recombine_handler_factory` (TIES merge) remains
+  `NotImplementedError` — follow-up PR once the 32-expert
+  curriculum stabilises.
+
 ## [C-v0.8.0+PARTIAL] — 2026-04-21
 
 ### Added — kiki_oniric.axioms public API (FC-MINOR bump)

--- a/kiki_oniric/substrates/micro_kiki.py
+++ b/kiki_oniric/substrates/micro_kiki.py
@@ -25,16 +25,19 @@ condition-1 surface ; DR-2 / DR-4 defer to phase 4 (conformance
 harness over the 3-substrate matrix).
 
 Phase boundaries (explicit) :
-- **Phase 1 (this file)** : replay + downscale operational on
-  LoRA adapter tensors, restructure + recombine stubbed with an
-  explicit ``NotImplementedError`` citing the blocker.
-- **Phase 2** : OPLoRA projection wired in (restructure) ; TIES-
-  style merge (recombine) once the 32-expert curriculum stabilises.
+- **Phase 1** : replay + downscale operational on LoRA adapter
+  tensors, restructure + recombine stubbed with an explicit
+  ``NotImplementedError`` citing the blocker.
+- **Phase 2 (this file)** : OPLoRA projection wired in
+  (restructure ; arXiv 2510.13003 Du et al.) ; TIES-style merge
+  (recombine) still stubbed, lands once the 32-expert curriculum
+  stabilises.
 - **Phase 3** : swap / eval_retained bindings + cross-substrate
   ablation (cycle-3 G10 Gate D).
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -43,12 +46,167 @@ import numpy as np
 from numpy.typing import NDArray
 
 
+_LOG = logging.getLogger(__name__)
+
+
 # DualVer C-v0.7.0+PARTIAL — aligned to the other cycle-3 substrates
 # (``esnn_thalamocortical`` + ``esnn_norse``). Phase 2 (restructure
 # + recombine real backends) will bump EC axis only ; the formal
 # axis tracks upstream framework-C spec changes.
 MICRO_KIKI_SUBSTRATE_NAME = "micro_kiki"
 MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.7.0+PARTIAL"
+
+
+# -----------------------------------------------------------------
+# OPLoRA (Orthogonal-Projection LoRA, arXiv 2510.13003, Du et al.)
+# -----------------------------------------------------------------
+# Given ``k`` prior LoRA deltas ``Δ_i = B_i · A_i`` (each of shape
+# ``(out_dim, in_dim)``), OPLoRA constructs a projector ``P`` onto
+# the orthogonal complement of the column space spanned by the
+# priors. When a new adapter B-matrix ``B_new`` is restructured we
+# replace it with ``P · B_new``, which guarantees that the new
+# contribution ``P · B_new · A_new · x`` is orthogonal to every
+# prior range — i.e. the new stack cannot overwrite features
+# already encoded in the retained subspace.
+#
+# The micro-kiki *training* pipeline uses torch (see local impl
+# ``src/stacks/oplora.py``) ; the substrate runs on the dream
+# runtime which is pure numpy (no torch / mlx dep), so this is a
+# pure-linear-algebra port. The algebra is identical :
+#
+#   torch                                                 numpy
+#   -----------------------------------------------      -------------------------------------------------
+#   Q, _ = torch.linalg.qr(prior.float())                U, S, _Vt = np.linalg.svd(prior, full_matrices=False)
+#   P    = I - Q @ Q.T                                   U_trim = U[:, S > rank_thresh]
+#                                                        P      = I - U_trim @ U_trim.T
+#
+# The numpy port uses SVD rather than QR so we can filter out the
+# near-zero singular values (rank selection via ``rank_thresh``) :
+# QR would include numerical-noise columns in ``Q``, over-pruning
+# the projected subspace. SVD + singular-value filter is the
+# standard OPLoRA recipe (paper §3.2).
+# -----------------------------------------------------------------
+
+
+def _oplora_projector(
+    prior_deltas: list[NDArray] | tuple[NDArray, ...],
+    rank_thresh: float = 1e-4,
+) -> NDArray:
+    """Build the OPLoRA orthogonal-complement projector ``P``.
+
+    Parameters
+    ----------
+    prior_deltas
+        Iterable of prior-adapter delta matrices (each ``B_i @ A_i``,
+        shape ``(out_dim, in_dim)``). All must share the same
+        ``out_dim`` — the first axis is what the projector acts on
+        (columns of ``B_new``). An empty iterable returns the
+        identity (no prior subspace to exclude).
+    rank_thresh
+        Singular-value magnitude below which a direction is treated
+        as numerical noise and dropped from the prior subspace. The
+        paper uses ``1e-4`` (§3.2).
+
+    Returns
+    -------
+    P : ndarray of shape ``(out_dim, out_dim)``
+        Orthogonal-complement projector. Satisfies ``P == P.T``,
+        ``P @ P ≈ P``, and ``P @ v ≈ 0`` for any ``v`` in the prior
+        column space.
+
+    Notes
+    -----
+    Guarded against two numerical failure modes :
+
+    1. **Zero-singular-value rank collapse** : if *all* singular
+       values of the stacked prior fall below ``rank_thresh``
+       (pathological : priors are numerical noise), we fall back
+       to ``P = I`` with a warning. The new adapter is not
+       projected away.
+    2. **Shape mismatch across priors** : explicit ``ValueError``
+       raised rather than silently broadcasting — the caller
+       must make the priors shape-consistent before handing them
+       in. Guards against a whole class of latent bugs where a
+       reshape earlier in the pipeline slips through.
+
+    Reference : Du et al., *OPLoRA: Orthogonal Projection for
+    LoRA Continual Learning*, arXiv 2510.13003, §3.2 (projector
+    construction) + §3.3 (rank-threshold robustness study).
+    """
+    deltas = list(prior_deltas)
+    if not deltas:
+        # No priors → nothing to project away. Identity is the
+        # correct (and well-defined) fallback.
+        raise ValueError(
+            "OPLoRA _oplora_projector requires at least one "
+            "prior delta ; pass ``np.eye(out_dim)`` as the "
+            "pseudo-prior if you want the no-op branch"
+        )
+    out_dims = {d.shape[0] for d in deltas}
+    if len(out_dims) != 1:
+        raise ValueError(
+            f"OPLoRA: all prior deltas must share out_dim "
+            f"(axis 0), got {sorted(out_dims)}"
+        )
+    (out_dim,) = out_dims
+
+    # Stack priors column-wise : the combined column space is the
+    # union of each prior's range, exactly what the projector must
+    # annihilate.
+    stacked = np.concatenate(
+        [np.asarray(d, dtype=np.float64) for d in deltas], axis=1
+    )
+    # SVD on the stacked prior matrix. ``U`` columns span the
+    # range of ``stacked`` ; filter by singular-value magnitude
+    # to drop numerical-noise directions.
+    try:
+        U, S, _Vt = np.linalg.svd(stacked, full_matrices=False)
+    except np.linalg.LinAlgError as exc:  # pragma: no cover
+        _LOG.warning(
+            "OPLoRA: SVD failed on stacked prior (%s) ; falling "
+            "back to identity projector",
+            exc,
+        )
+        return np.eye(out_dim, dtype=np.float32)
+
+    keep = S > rank_thresh
+    if not keep.any():
+        _LOG.warning(
+            "OPLoRA: all %d singular values below rank_thresh=%g "
+            "; prior subspace is effectively empty, returning "
+            "identity projector",
+            S.size, rank_thresh,
+        )
+        return np.eye(out_dim, dtype=np.float32)
+
+    U_trim = U[:, keep]
+    identity = np.eye(out_dim, dtype=np.float64)
+    P = identity - U_trim @ U_trim.T
+    # Cast back to float32 — the rest of the substrate stores LoRA
+    # tensors in float32 (matches mlx adapter dtype).
+    return P.astype(np.float32, copy=False)
+
+
+@dataclass
+class MicroKikiRestructureState:
+    """DR-0 accountability record for the OPLoRA restructure op.
+
+    Each invocation of the :meth:`restructure_handler_factory`
+    closure bumps ``total_episodes_handled`` and appends the
+    episode id (if supplied via ``adapter["episode_id"]``) to
+    ``episode_ids``. ``completed`` + ``operation`` are mirrored
+    on the last-handled record so DR-0 traceability is preserved
+    (``completed=True`` + ``operation='restructure'``). The state
+    is read by the conformance harness to verify DR-1 (episodic
+    stamp consistency) across the 3-substrate matrix.
+    """
+
+    total_episodes_handled: int = 0
+    total_projections_applied: int = 0
+    last_episode_id: str | None = None
+    last_operation: str = "restructure"
+    last_completed: bool = False
+    episode_ids: list[str] = field(default_factory=list)
 
 # Optional-dependency probe : ``mlx_lm`` (Apple Silicon MLX wheel
 # + LoRA adapters) is imported lazily inside the method that
@@ -113,6 +271,15 @@ class MicroKikiSubstrate:
     # :meth:`snapshot` / :meth:`load_snapshot` as a numpy ``.npz``.
     _current_delta: dict[str, NDArray] = field(
         default_factory=dict, init=False, repr=False,
+    )
+    # DR-0 accountability state for the OPLoRA restructure handler
+    # (arXiv 2510.13003). Exposed read-only via :meth:`restructure_state`
+    # so the conformance harness can assert DR-1 (episode_id stamp
+    # consistency) without poking private attributes.
+    _restructure_state: MicroKikiRestructureState = field(
+        default_factory=MicroKikiRestructureState,
+        init=False,
+        repr=False,
     )
     _rng: np.random.Generator = field(init=False, repr=False)
 
@@ -234,29 +401,116 @@ class MicroKikiSubstrate:
 
     def restructure_handler_factory(
         self,
+        rank_thresh: float = 1e-4,
     ) -> Callable[[dict, str, str], dict]:
-        """D-Friston FEP restructure → **phase-2 stub**.
+        """D-Friston FEP restructure → **OPLoRA projection (phase 2)**.
 
-        Raises ``NotImplementedError`` : real implementation
-        requires OPLoRA (arXiv 2510.13003) projection to preserve
-        the S1 retained-benchmark invariant while swapping LoRA
-        ranks or adding / removing target layers. The projection
-        is wired into the MLX pipeline in phase 2 of the micro-
-        kiki roadmap ; until then the D-Friston operation surface
-        on this substrate is deliberately empty so the gate is
-        visible to the cycle-3 conformance run.
+        Wires the Orthogonal-Projection LoRA algorithm of Du et
+        al. (arXiv 2510.13003) : given a list of prior-stack
+        adapter deltas carried on ``adapter["prior_deltas"]``, the
+        handler builds the projector ``P = I - U U^T`` onto the
+        orthogonal complement of the priors' range and replaces
+        the new adapter's B-matrix by ``P @ B_new``. The
+        contribution ``P · B_new · A_new · x`` is then orthogonal
+        to every prior range, preserving the S1 retained-benchmark
+        invariant across sequential stack additions.
+
+        Handler contract
+        ----------------
+        ``adapter`` is a mutable dict keyed by LoRA tensor name. It
+        *must* carry :
+
+        - ``"prior_deltas"`` : ``list[ndarray]`` of prior
+          ``B_i @ A_i`` products (shape ``(out_dim, in_dim_i)``).
+          Empty list means no priors to project away — handler
+          returns the adapter unchanged (no-op).
+        - ``key`` (the third positional arg) : name of the
+          B-matrix entry to project. Its shape must be
+          ``(out_dim, rank)`` with ``out_dim`` matching the
+          priors.
+        - Optional ``"episode_id"`` : DR-0 stamp propagated into
+          :attr:`_restructure_state`.
+
+        ``op`` is accepted for signature-compat with the phase-1
+        stub but currently only ``"oplora"`` is honoured (the
+        default). Any other value raises ``ValueError`` — keeps
+        the gate explicit per DR-3 condition-1 (no silent
+        no-ops).
+
+        Returns the same ``adapter`` dict (with the entry at
+        ``key`` replaced by ``P @ adapter[key]``).
+
+        Reference : Du et al., arXiv 2510.13003 §3.2-§3.3. The
+        local micro-kiki training pipeline at
+        ``src/stacks/oplora.py`` (torch) mirrors this algebra ;
+        this numpy port lives substrate-side for the dream
+        runtime's no-torch constraint.
         """
 
         def handler(
             adapter: dict[str, NDArray], op: str, key: str,
         ) -> dict[str, NDArray]:
-            raise NotImplementedError(
-                "restructure_handler requires OPLoRA projection "
-                "(arXiv 2510.13003) — phase 2 of the micro-kiki "
-                "roadmap wires it into the MLX tuner pipeline"
-            )
+            if op not in {"oplora", "oplora_project", "project"}:
+                raise ValueError(
+                    f"micro_kiki.restructure_handler: unsupported "
+                    f"op {op!r} ; expected one of "
+                    f"{{'oplora', 'oplora_project', 'project'}}"
+                )
+            if key not in adapter:
+                raise KeyError(
+                    f"micro_kiki.restructure_handler: adapter "
+                    f"missing entry for key {key!r}"
+                )
+            new_B = np.asarray(adapter[key])
+            if new_B.ndim != 2:
+                raise ValueError(
+                    f"micro_kiki.restructure_handler: adapter[{key!r}] "
+                    f"must be 2-D (out_dim, rank), got shape "
+                    f"{new_B.shape}"
+                )
+
+            priors = list(adapter.get("prior_deltas", []))
+            episode_id = adapter.get("episode_id")
+
+            if priors:
+                P = _oplora_projector(priors, rank_thresh=rank_thresh)
+                if P.shape[0] != new_B.shape[0]:
+                    raise ValueError(
+                        f"micro_kiki.restructure_handler: projector "
+                        f"out_dim {P.shape[0]} != adapter[{key!r}] "
+                        f"out_dim {new_B.shape[0]}"
+                    )
+                projected = (P @ new_B.astype(np.float32)).astype(
+                    new_B.dtype, copy=False,
+                )
+                adapter[key] = projected
+                self._restructure_state.total_projections_applied += 1
+
+            # DR-0 bookkeeping : always bump the counter + record
+            # the episode (even when priors is empty — the op was
+            # invoked, and DR-0 credits every handler call, not
+            # just those with a non-trivial effect).
+            self._restructure_state.total_episodes_handled += 1
+            self._restructure_state.last_completed = True
+            self._restructure_state.last_operation = "restructure"
+            if isinstance(episode_id, str):
+                self._restructure_state.last_episode_id = episode_id
+                self._restructure_state.episode_ids.append(episode_id)
+            return adapter
 
         return handler
+
+    @property
+    def restructure_state(self) -> MicroKikiRestructureState:
+        """Read-only accessor for the OPLoRA DR-0 record.
+
+        Exposed so the conformance harness (and unit tests) can
+        assert DR-0 (completed flag, operation label) + DR-1
+        (episode_id stamp propagation) without poking private
+        attributes. The returned object is the live state dataclass
+        — do not mutate ; it is refreshed by each handler call.
+        """
+        return self._restructure_state
 
     def recombine_handler_factory(
         self,

--- a/tests/unit/test_micro_kiki_restructure.py
+++ b/tests/unit/test_micro_kiki_restructure.py
@@ -1,0 +1,290 @@
+"""OPLoRA restructure tests — micro-kiki substrate, cycle-3 phase 2.
+
+Covers the OPLoRA projection wired into
+:meth:`MicroKikiSubstrate.restructure_handler_factory` (arXiv
+2510.13003, Du et al.). The paper's key invariants and the dream
+runtime's DR-0 / DR-1 axioms are asserted in parallel :
+
+- *Algebra* (paper §3.2) : ``P @ v = 0`` for ``v`` in the prior
+  subspace ; ``P @ w = w`` for ``w`` in its orthogonal
+  complement ; ``P`` is symmetric idempotent (``P @ P ≈ P``).
+- *DR-0* (accountability) : every handler call bumps the
+  ``restructure_state`` counters ; ``completed=True`` and
+  ``operation='restructure'`` are recorded.
+- *DR-1* (episodic stamp) : an ``episode_id`` carried on the
+  adapter dict is propagated to ``state.last_episode_id`` and
+  appended to ``state.episode_ids``.
+
+These tests are numpy-only and run on any host (no MLX / torch
+dep). Reference :
+``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md`` §6.2
+(DR-0, DR-1, DR-3).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kiki_oniric.substrates.micro_kiki import (
+    MicroKikiRestructureState,
+    MicroKikiSubstrate,
+    _oplora_projector,
+)
+
+
+# ---------------------------------------------------------------
+# _oplora_projector — pure-function algebra
+# ---------------------------------------------------------------
+
+
+def test_projector_orthogonality() -> None:
+    """Projector annihilates every column of every prior delta.
+
+    Paper §3.2 : ``P = I - U U^T`` where ``U`` spans the column
+    space of the stacked priors ; therefore ``P @ v = 0`` for
+    any ``v`` that lies in that span — in particular, every
+    column of every prior delta.
+    """
+    rng = np.random.default_rng(7)
+    out_dim = 8
+    priors = [
+        rng.standard_normal((out_dim, 3)).astype(np.float32),
+        rng.standard_normal((out_dim, 2)).astype(np.float32),
+    ]
+    P = _oplora_projector(priors)
+    assert P.shape == (out_dim, out_dim)
+    for prior in priors:
+        projected = P @ prior
+        np.testing.assert_allclose(
+            projected, np.zeros_like(projected), atol=1e-5,
+        )
+
+
+def test_projector_preserves_orthogonal_complement() -> None:
+    """Vectors orthogonal to the prior subspace pass through unchanged.
+
+    Construct a small prior whose column space is exactly
+    ``span(e_0, e_1)`` ; pick ``w = e_3`` which is orthogonal to
+    that span ; assert ``P @ w ≈ w``.
+    """
+    out_dim = 6
+    prior = np.zeros((out_dim, 2), dtype=np.float32)
+    prior[0, 0] = 1.0  # column 0 == e_0
+    prior[1, 1] = 1.0  # column 1 == e_1
+    P = _oplora_projector([prior])
+
+    w = np.zeros(out_dim, dtype=np.float32)
+    w[3] = 1.0
+    np.testing.assert_allclose(P @ w, w, atol=1e-6)
+
+    # ``P`` is symmetric.
+    np.testing.assert_allclose(P, P.T, atol=1e-6)
+    # Idempotent : ``P @ P == P``.
+    np.testing.assert_allclose(P @ P, P, atol=1e-5)
+
+
+def test_projector_shape_mismatch_raises() -> None:
+    """Different ``out_dim`` across priors is a caller bug."""
+    p1 = np.zeros((4, 2), dtype=np.float32)
+    p2 = np.zeros((5, 2), dtype=np.float32)
+    with pytest.raises(ValueError, match="out_dim"):
+        _oplora_projector([p1, p2])
+
+
+def test_projector_empty_priors_rejected() -> None:
+    """Empty prior list → explicit error (caller handles the no-op).
+
+    The handler path treats empty priors as a DR-0-credited no-op,
+    but the pure helper is stricter : it must see at least one
+    prior so the fallback semantics stay visible to callers.
+    """
+    with pytest.raises(ValueError, match="at least one"):
+        _oplora_projector([])
+
+
+def test_projector_rank_collapse_falls_back_to_identity() -> None:
+    """All singular values below ``rank_thresh`` → ``P = I``.
+
+    Paper §3.3 robustness study : if the priors degenerate to
+    numerical noise the projector collapses to identity (i.e.
+    we refuse to over-prune a meaningful new adapter based on
+    noise).
+    """
+    out_dim = 4
+    # Near-zero prior ; every singular value below the default
+    # threshold of 1e-4.
+    prior = np.full((out_dim, 2), 1e-8, dtype=np.float32)
+    P = _oplora_projector([prior], rank_thresh=1e-4)
+    np.testing.assert_allclose(
+        P, np.eye(out_dim, dtype=np.float32), atol=1e-6,
+    )
+
+
+# ---------------------------------------------------------------
+# restructure_handler_factory — DR-0 / DR-1 contract
+# ---------------------------------------------------------------
+
+
+def test_restructure_handler_callable() -> None:
+    """Factory returns a callable (DR-3 condition 1)."""
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    assert callable(handler)
+    # Factory also returns a fresh state container.
+    assert isinstance(substrate.restructure_state, MicroKikiRestructureState)
+
+
+def test_restructure_consumes_episode_projects_new_B() -> None:
+    """End-to-end : 2 priors + 1 new B-matrix ⇒ projected B is
+    orthogonal to every prior range, adapter dict mutated in
+    place, DR-0 counters bumped.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    rng = np.random.default_rng(42)
+    out_dim = 8
+    rank = 2
+    priors = [
+        rng.standard_normal((out_dim, 3)).astype(np.float32),
+        rng.standard_normal((out_dim, 4)).astype(np.float32),
+    ]
+    # Intentionally pick a new B-matrix NOT orthogonal to priors —
+    # the projection must move it.
+    new_B_original = rng.standard_normal((out_dim, rank)).astype(np.float32)
+
+    adapter: dict = {
+        "layers.5.q_proj_B": new_B_original.copy(),
+        "prior_deltas": priors,
+        "episode_id": "ep-restruct-42",
+    }
+    out = handler(adapter, "oplora", "layers.5.q_proj_B")
+
+    projected_B = out["layers.5.q_proj_B"]
+    # Shape + dtype preserved.
+    assert projected_B.shape == new_B_original.shape
+    assert projected_B.dtype == new_B_original.dtype
+
+    # Projected-B columns orthogonal to every prior-delta column.
+    for prior in priors:
+        cross = prior.T @ projected_B
+        np.testing.assert_allclose(
+            cross, np.zeros_like(cross), atol=1e-4,
+        )
+
+    # The projection was non-trivial (new_B wasn't already in the
+    # orthogonal complement). Sanity check the test setup.
+    assert not np.allclose(projected_B, new_B_original, atol=1e-3)
+
+    # DR-0 bookkeeping — completed flag, operation label, counters.
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 1
+    assert state.last_completed is True
+    assert state.last_operation == "restructure"
+
+
+def test_restructure_dr1_episode_id_stamping() -> None:
+    """DR-1 — every episode_id carried on the adapter dict lands
+    on the state in order ; unstamped calls skip the append but
+    still bump the counter.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    rng = np.random.default_rng(1)
+    out_dim = 4
+    prior = rng.standard_normal((out_dim, 2)).astype(np.float32)
+    B0 = rng.standard_normal((out_dim, 2)).astype(np.float32)
+
+    for eid in ("e0", "e1", "e2"):
+        adapter: dict = {
+            "B": B0.copy(),
+            "prior_deltas": [prior],
+            "episode_id": eid,
+        }
+        handler(adapter, "oplora", "B")
+
+    # Unstamped call — state.last_episode_id sticks at "e2",
+    # episode_ids list not appended, counter bumped.
+    handler(
+        {"B": B0.copy(), "prior_deltas": [prior]},
+        "oplora",
+        "B",
+    )
+
+    state = substrate.restructure_state
+    assert state.episode_ids == ["e0", "e1", "e2"]
+    assert state.last_episode_id == "e2"
+    assert state.total_episodes_handled == 4
+    assert state.total_projections_applied == 4
+
+
+def test_restructure_empty_priors_is_dr0_noop() -> None:
+    """Empty ``prior_deltas`` — handler is a DR-0-credited no-op.
+
+    The adapter dict is returned unchanged (no projection applied)
+    but the episode is still recorded : DR-0 credits every
+    handler invocation, even those with no net effect on the
+    adapter tensors. ``total_projections_applied`` stays at 0 so
+    callers can audit the no-op leg.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    B = np.ones((3, 2), dtype=np.float32)
+    adapter: dict = {
+        "B": B.copy(),
+        "prior_deltas": [],
+        "episode_id": "ep-noop",
+    }
+    out = handler(adapter, "oplora", "B")
+    np.testing.assert_array_equal(out["B"], B)
+
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 0
+    assert state.last_episode_id == "ep-noop"
+    assert state.last_completed is True
+
+
+def test_restructure_rejects_wrong_op() -> None:
+    """DR-3 condition 1 : unknown op-names fail loud.
+
+    Silent fallbacks would mask dispatcher bugs in the
+    conformance harness ; the handler only honours the OPLoRA
+    op vocabulary.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    adapter = {"B": np.zeros((2, 2), dtype=np.float32), "prior_deltas": []}
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler(adapter, "merge", "B")
+
+
+def test_restructure_rejects_missing_key() -> None:
+    """Missing B-matrix key → explicit KeyError.
+
+    Pairs with the op-vocabulary guard above : caller bugs surface
+    at the handler boundary, not as a downstream shape mismatch.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    adapter: dict = {"prior_deltas": []}
+    with pytest.raises(KeyError, match="missing entry"):
+        handler(adapter, "oplora", "does_not_exist")
+
+
+def test_restructure_rejects_projector_shape_mismatch() -> None:
+    """Prior out_dim ≠ new-B out_dim is a caller bug ; raise."""
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    prior = np.ones((5, 2), dtype=np.float32)  # out_dim = 5
+    new_B = np.ones((4, 2), dtype=np.float32)  # out_dim = 4
+    adapter: dict = {
+        "B": new_B,
+        "prior_deltas": [prior],
+    }
+    with pytest.raises(ValueError, match="out_dim"):
+        handler(adapter, "oplora", "B")

--- a/tests/unit/test_micro_kiki_substrate.py
+++ b/tests/unit/test_micro_kiki_substrate.py
@@ -100,18 +100,41 @@ def test_downscale_preserves_shape_and_rejects_invalid_factor() -> None:
         handler(weights, factor=1.5)
 
 
-def test_restructure_raises_phase_2() -> None:
-    """TDD-4 — restructure factory returns a callable that raises
-    ``NotImplementedError`` with an explicit phase-2 / OPLoRA
-    citation. The gate is deliberately visible so the cycle-3
-    conformance run surfaces it as a known-missing branch rather
-    than silently no-opping.
+def test_restructure_handler_oplora_wired() -> None:
+    """TDD-4 (phase-2) — restructure factory returns an OPLoRA-
+    backed callable (arXiv 2510.13003). Empty ``prior_deltas``
+    is a DR-0-credited no-op ; the full algebra is exercised in
+    ``tests/unit/test_micro_kiki_restructure.py``.
+
+    The phase-1 ``NotImplementedError`` gate is retired here in
+    favour of an assertion that the op is *wired* ; the gate is
+    now covered by the dedicated OPLoRA test module so the DR-3
+    conformance harness sees the real surface, not a stub.
     """
     substrate = MicroKikiSubstrate()
     handler = substrate.restructure_handler_factory()
     assert callable(handler)
-    with pytest.raises(NotImplementedError, match="OPLoRA"):
-        handler({}, "activate", "layers.0.q_proj")
+
+    adapter: dict = {
+        "layers.0.q_proj_B": np.zeros((4, 2), dtype=np.float32),
+        "prior_deltas": [],  # empty → no-op projection leg
+        "episode_id": "ep-restruct-0",
+    }
+    out = handler(adapter, "oplora", "layers.0.q_proj_B")
+    # No priors → adapter entry unchanged ; state still bumped.
+    np.testing.assert_array_equal(
+        out["layers.0.q_proj_B"], np.zeros((4, 2), dtype=np.float32),
+    )
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 0
+    assert state.last_completed is True
+    assert state.last_operation == "restructure"
+    assert state.last_episode_id == "ep-restruct-0"
+
+    # Unsupported op still rejected — DR-3 visibility.
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler(adapter, "activate", "layers.0.q_proj_B")
 
 
 def test_recombine_raises_phase_2() -> None:


### PR DESCRIPTION
## What
Wires OPLoRA (Du et al., arXiv 2510.13003) into the `micro_kiki` substrate's
`restructure_handler`. Replaces the `NotImplementedError` stub that landed in
PR #9.

## Why
Enables the `micro_kiki` substrate to participate in DR-2 compositionality
tests. Mirrors the torch-based implementation used in the parent micro-kiki
project (`src/stacks/oplora.py`); ported to numpy here so `dream-of-kiki`
stays torch-free.

## Algorithm
Given prior adapter deltas `[B_i @ A_i]`, build the projector
`P = I - U U^T` where `U` stacks left-singular vectors (sigma > 1e-4) of the
stacked priors. Restructure applies `P` to the new adapter's B-matrix before
injection. This preserves DR-2' canonical order (replay -> restructure).

Numerical guards:
- Empty priors: handler treats as DR-0-credited no-op (returns adapter
  unchanged, bumps counter, stamps `episode_id`). The `_oplora_projector`
  helper itself rejects empty input with an explicit `ValueError` so the
  no-op semantics stay visible to callers.
- Shape mismatch across priors: explicit `ValueError`.
- Rank-collapse (all singular values below `rank_thresh`): falls back to
  identity with a log warning.
- Projector out-dim vs new-B out-dim mismatch: explicit `ValueError`.

## Testing
- 12 new unit tests in `tests/unit/test_micro_kiki_restructure.py` (projector
  algebra: orthogonality, idempotence, symmetry, rank-collapse fallback,
  shape-mismatch guard; handler contract: DR-0 counters, DR-1 stamping,
  op-vocabulary guard, missing-key guard, projector shape guard).
- `tests/unit/test_micro_kiki_substrate.py` retires the phase-1
  `NotImplementedError` gate in favour of an OPLoRA-wired assertion.
- Full `tests/unit/` regression green (242 passed, 7 skipped on Linux venv;
  the 3 MLX-only collection errors are pre-existing and unrelated to this
  PR).
- Ready for Mac Studio conformance re-run on base `main` once PR #9 merges.

## Dependency
Stacked on PR #9 (`feat/micro-kiki-substrate`). Opened as draft against
`feat/micro-kiki-substrate` so the diff shows only the OPLoRA work. Rebase
to `main` after #9 merges; then mark ready-for-review.

## Follow-up
- `recombine_handler_factory` (TIES-style LoRA merge) — separate PR once
  the 32-expert curriculum stabilises.
- Env-gated real-`mlx_lm` leg for Mac Studio DR-3 real-compute pass.
