### PR TITLE
feat(substrates): add micro_kiki + OPLoRA wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,62 @@ see `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12).
 
 ---
 
+## [C-v0.9.0+PARTIAL] — 2026-04-22
+
+### Added — micro-kiki LoRA substrate (FC-MINOR bump)
+
+Third substrate for framework C, wrapping the
+[`micro-kiki`](https://github.com/kxkm-ai/micro-kiki) project's Qwen
+MoE + LoRA adapter training output. Extends the DR-3 Conformance
+Criterion surface from 2 substrates (MLX kiki-oniric + E-SNN
+thalamocortical/Norse) to 3, adding a transformer-LoRA leg
+alongside the SNN legs. Substrate-internal version:
+`C-v0.8.0+PARTIAL`.
+
+**Handlers backed (3/4)**
+
+- `replay_handler_factory` + `downscale_handler_factory` operate
+  over numpy tensors (CI fallback) and LoRA tensors (Apple Silicon
+  path, env-gated on `mlx_lm`).
+- `restructure_handler_factory` wires OPLoRA (Du et al., arXiv
+  2510.13003): projects new adapter deltas onto the orthogonal
+  complement of the prior subspace via numpy SVD. Module-level
+  helper `_oplora_projector(prior_deltas, rank_thresh=1e-4)`.
+  Guards: empty priors reject (caller handles no-op leg via
+  handler), shape-mismatch across priors raises, rank collapse
+  falls back to identity projector with a warning, **and
+  full-rank saturation logs a warning** (priors spanning the
+  full output space silently zero new adapters — the warning
+  makes that visible to the curriculum scheduler). Read-only
+  `MicroKikiRestructureState` dataclass exposed via
+  `MicroKikiSubstrate.restructure_state` records DR-0 completion
+  flag + operation label and DR-1 `episode_id` stamps.
+
+**Stub deferred to phase 3 (1/4)**
+
+- `recombine_handler_factory` (TIES-merge, Yadav et al., arXiv
+  2306.01708) raises `NotImplementedError` with explicit
+  citation. Surfaced rather than silently no-op'd so the gap
+  stays visible in the cycle-3 conformance matrix. Unblocks once
+  the 32-expert micro-kiki curriculum stabilises.
+
+**Persistence + tests**
+
+- `snapshot` / `load_snapshot` round-trip the accumulator delta
+  via numpy `.npz` (portable across the 3-substrate test matrix).
+- 30 tests across three files: `test_micro_kiki_substrate.py`
+  (7 unit tests : manifest shape, handler signatures, DR-1 shape
+  preservation on downscale, snapshot round-trip, OPLoRA-wired
+  assertion replacing the phase-1 `NotImplementedError` gate),
+  `test_micro_kiki_restructure.py` (13 unit tests : projector
+  orthogonality, idempotence, symmetry, rank-collapse fallback,
+  full-rank saturation warning, shape-mismatch guard, DR-0
+  counters, DR-1 stamping, op-vocabulary guard, missing-key guard,
+  projector shape guard) and
+  `tests/conformance/axioms/test_dr3_micro_kiki_substrate.py` (10
+  conformance tests covering the 3 DR-3 conditions for the
+  substrate, parametrising the cycle-3 matrix entry).
+
 ## [C-v0.8.0+PARTIAL] — 2026-04-21
 
 ### Added — kiki_oniric.axioms public API (FC-MINOR bump)

--- a/kiki_oniric/substrates/__init__.py
+++ b/kiki_oniric/substrates/__init__.py
@@ -23,6 +23,12 @@ from kiki_oniric.substrates.esnn_thalamocortical import (
     EsnnSubstrate,
     esnn_substrate_components,
 )
+from kiki_oniric.substrates.micro_kiki import (
+    MICRO_KIKI_SUBSTRATE_NAME,
+    MICRO_KIKI_SUBSTRATE_VERSION,
+    MicroKikiSubstrate,
+    micro_kiki_substrate_components,
+)
 
 __all__ = [
     "MLX_SUBSTRATE_NAME",
@@ -33,4 +39,8 @@ __all__ = [
     "EsnnBackend",
     "EsnnSubstrate",
     "esnn_substrate_components",
+    "MICRO_KIKI_SUBSTRATE_NAME",
+    "MICRO_KIKI_SUBSTRATE_VERSION",
+    "MicroKikiSubstrate",
+    "micro_kiki_substrate_components",
 ]

--- a/kiki_oniric/substrates/micro_kiki.py
+++ b/kiki_oniric/substrates/micro_kiki.py
@@ -1,0 +1,614 @@
+"""micro-kiki substrate — Qwen MoE + LoRA (cycle-3 Phase 2, draft).
+
+Third substrate for dreamOfkiki, wrapping the micro-kiki project's
+adapter-training output. The intended production base is
+``Qwen/Qwen3.5-35B-A3B`` (native 256-expert MoE, 3 B active per
+token) with a standard LoRA adapter trained on 32 domain experts.
+The substrate is however base-model agnostic ; any MLX-loadable
+checkpoint with a companion LoRA ``adapters.safetensors`` is
+acceptable.
+
+Backend choice :
+- ``mlx_lm`` (default) : declared target. When importable, the
+  substrate loads the model + adapter lazily at :meth:`load`
+  time and ``awake`` dispatches to ``mlx_lm.generate``.
+- **Stub fallback** : when ``mlx_lm`` (or its ``mlx`` parent) is
+  unavailable — the default on Linux CI — the substrate builds
+  cleanly and exposes the 4 op-handler factories over numpy
+  tensors only. This matches the pattern from
+  ``esnn_norse`` (env-gated real backend + numpy fallback) so
+  the DR-3 condition-1 test surface is exercised on every host.
+
+Reference : ``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md``
+§6.2 (DR-3 Conformance Criterion). Scope : DR-0 / DR-1 / DR-3
+condition-1 surface ; DR-2 / DR-4 defer to phase 4 (conformance
+harness over the 3-substrate matrix).
+
+Phase boundaries (explicit) :
+- **Phase 1** : replay + downscale operational on LoRA adapter
+  tensors, restructure + recombine stubbed with an explicit
+  ``NotImplementedError`` citing the blocker.
+- **Phase 2 (this file)** : OPLoRA projection wired in
+  (restructure ; arXiv 2510.13003 Du et al.) ; TIES-style merge
+  (recombine) still stubbed, lands once the 32-expert curriculum
+  stabilises.
+- **Phase 3** : swap / eval_retained bindings + cross-substrate
+  ablation (cycle-3 G10 Gate D).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+_LOG = logging.getLogger(__name__)
+
+
+# DualVer C-v0.8.0+PARTIAL — restructure (OPLoRA) wired ; recombine
+# (TIES-merge) remains the only stub. Aligned to the sibling cycle-3
+# substrates (``esnn_thalamocortical`` + ``esnn_norse``). Phase 2
+# completion (recombine real backend) will bump EC axis only ; the
+# formal axis tracks upstream framework-C spec changes.
+MICRO_KIKI_SUBSTRATE_NAME = "micro_kiki"
+MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.8.0+PARTIAL"
+
+
+# -----------------------------------------------------------------
+# OPLoRA (Orthogonal-Projection LoRA, arXiv 2510.13003, Du et al.)
+# -----------------------------------------------------------------
+# Given ``k`` prior LoRA deltas ``Δ_i = B_i · A_i`` (each of shape
+# ``(out_dim, in_dim)``), OPLoRA constructs a projector ``P`` onto
+# the orthogonal complement of the column space spanned by the
+# priors. When a new adapter B-matrix ``B_new`` is restructured we
+# replace it with ``P · B_new``, which guarantees that the new
+# contribution ``P · B_new · A_new · x`` is orthogonal to every
+# prior range — i.e. the new stack cannot overwrite features
+# already encoded in the retained subspace.
+#
+# The micro-kiki *training* pipeline uses torch (see local impl
+# ``src/stacks/oplora.py``) ; the substrate runs on the dream
+# runtime which is pure numpy (no torch / mlx dep), so this is a
+# pure-linear-algebra port. The algebra is identical :
+#
+#   torch                                                 numpy
+#   -----------------------------------------------      -------------------------------------------------
+#   Q, _ = torch.linalg.qr(prior.float())                U, S, _Vt = np.linalg.svd(prior, full_matrices=False)
+#   P    = I - Q @ Q.T                                   U_trim = U[:, S > rank_thresh]
+#                                                        P      = I - U_trim @ U_trim.T
+#
+# The numpy port uses SVD rather than QR so we can filter out the
+# near-zero singular values (rank selection via ``rank_thresh``) :
+# QR would include numerical-noise columns in ``Q``, over-pruning
+# the projected subspace. SVD + singular-value filter is the
+# standard OPLoRA recipe (paper §3.2).
+# -----------------------------------------------------------------
+
+
+def _oplora_projector(
+    prior_deltas: list[NDArray] | tuple[NDArray, ...],
+    rank_thresh: float = 1e-4,
+) -> NDArray:
+    """Build the OPLoRA orthogonal-complement projector ``P``.
+
+    Parameters
+    ----------
+    prior_deltas
+        Iterable of prior-adapter delta matrices (each ``B_i @ A_i``,
+        shape ``(out_dim, in_dim)``). All must share the same
+        ``out_dim`` — the first axis is what the projector acts on
+        (columns of ``B_new``). An empty iterable returns the
+        identity (no prior subspace to exclude).
+    rank_thresh
+        Singular-value magnitude below which a direction is treated
+        as numerical noise and dropped from the prior subspace. The
+        paper uses ``1e-4`` (§3.2).
+
+    Returns
+    -------
+    P : ndarray of shape ``(out_dim, out_dim)``
+        Orthogonal-complement projector. Satisfies ``P == P.T``,
+        ``P @ P ≈ P``, and ``P @ v ≈ 0`` for any ``v`` in the prior
+        column space.
+
+    Notes
+    -----
+    Guarded against two numerical failure modes :
+
+    1. **Zero-singular-value rank collapse** : if *all* singular
+       values of the stacked prior fall below ``rank_thresh``
+       (pathological : priors are numerical noise), we fall back
+       to ``P = I`` with a warning. The new adapter is not
+       projected away.
+    2. **Shape mismatch across priors** : explicit ``ValueError``
+       raised rather than silently broadcasting — the caller
+       must make the priors shape-consistent before handing them
+       in. Guards against a whole class of latent bugs where a
+       reshape earlier in the pipeline slips through.
+
+    Reference : Du et al., *OPLoRA: Orthogonal Projection for
+    LoRA Continual Learning*, arXiv 2510.13003, §3.2 (projector
+    construction) + §3.3 (rank-threshold robustness study).
+    """
+    deltas = list(prior_deltas)
+    if not deltas:
+        # No priors → nothing to project away. Identity is the
+        # correct (and well-defined) fallback.
+        raise ValueError(
+            "OPLoRA _oplora_projector requires at least one "
+            "prior delta ; pass ``np.eye(out_dim)`` as the "
+            "pseudo-prior if you want the no-op branch"
+        )
+    out_dims = {d.shape[0] for d in deltas}
+    if len(out_dims) != 1:
+        raise ValueError(
+            f"OPLoRA: all prior deltas must share out_dim "
+            f"(axis 0), got {sorted(out_dims)}"
+        )
+    (out_dim,) = out_dims
+
+    # Stack priors column-wise : the combined column space is the
+    # union of each prior's range, exactly what the projector must
+    # annihilate.
+    stacked = np.concatenate(
+        [np.asarray(d, dtype=np.float64) for d in deltas], axis=1
+    )
+    # SVD on the stacked prior matrix. ``U`` columns span the
+    # range of ``stacked`` ; filter by singular-value magnitude
+    # to drop numerical-noise directions.
+    try:
+        U, S, _Vt = np.linalg.svd(stacked, full_matrices=False)
+    except np.linalg.LinAlgError as exc:  # pragma: no cover
+        _LOG.warning(
+            "OPLoRA: SVD failed on stacked prior (%s) ; falling "
+            "back to identity projector",
+            exc,
+        )
+        return np.eye(out_dim, dtype=np.float32)
+
+    keep = S > rank_thresh
+    if not keep.any():
+        _LOG.warning(
+            "OPLoRA: all %d singular values below rank_thresh=%g "
+            "; prior subspace is effectively empty, returning "
+            "identity projector",
+            S.size, rank_thresh,
+        )
+        return np.eye(out_dim, dtype=np.float32)
+
+    U_trim = U[:, keep]
+    identity = np.eye(out_dim, dtype=np.float64)
+    P = identity - U_trim @ U_trim.T
+    # Full-rank saturation : when accumulated priors span the entire
+    # output space (a real, non-pathological case in long sequential
+    # multi-expert curricula), ``U_trim @ U_trim.T`` collapses to the
+    # identity and ``P`` to the zero matrix. The handler would then
+    # silently zero every new adapter. Surface this loudly so callers
+    # know to prune priors or widen ``out_dim``.
+    if np.linalg.norm(P, ord="fro") < rank_thresh * out_dim:
+        _LOG.warning(
+            "OPLoRA: projector is effectively zero — priors span "
+            "the full output space (rank=%d, out_dim=%d) ; new "
+            "adapter will be annihilated. Prune priors or widen "
+            "out_dim.",
+            U_trim.shape[1], out_dim,
+        )
+    # Cast back to float32 — the rest of the substrate stores LoRA
+    # tensors in float32 (matches mlx adapter dtype).
+    return np.asarray(P, dtype=np.float32)
+
+
+@dataclass
+class MicroKikiRestructureState:
+    """DR-0 accountability record for the OPLoRA restructure op.
+
+    Each invocation of the :meth:`restructure_handler_factory`
+    closure bumps ``total_episodes_handled`` and appends the
+    episode id (if supplied via ``adapter["episode_id"]``) to
+    ``episode_ids``. ``completed`` + ``operation`` are mirrored
+    on the last-handled record so DR-0 traceability is preserved
+    (``completed=True`` + ``operation='restructure'``). The state
+    is read by the conformance harness to verify DR-1 (episodic
+    stamp consistency) across the 3-substrate matrix.
+    """
+
+    total_episodes_handled: int = 0
+    total_projections_applied: int = 0
+    last_episode_id: str | None = None
+    last_operation: str = "restructure"
+    last_completed: bool = False
+    episode_ids: list[str] = field(default_factory=list)
+
+# Optional-dependency probe : ``mlx_lm`` (Apple Silicon MLX wheel
+# + LoRA adapters) is imported lazily inside the method that
+# actually needs it (:meth:`MicroKikiSubstrate.load`). We record
+# only a boolean flag at module-import so callers can introspect
+# availability without a second try-import. Tests cover the False
+# branch ; the True branch is env-gated on Apple Silicon.
+try:  # pragma: no cover - branch depends on env
+    import mlx_lm  # noqa: F401
+
+    _MLX_LM_AVAILABLE = True
+except ImportError:  # pragma: no cover - branch depends on env
+    _MLX_LM_AVAILABLE = False
+
+
+@dataclass
+class MicroKikiSubstrate:
+    """micro-kiki framework-C substrate (Qwen MoE + LoRA).
+
+    Parameters
+    ----------
+    base_model_path
+        Optional path (local dir or HF repo id) to an
+        ``mlx_lm``-loadable model. When ``None`` the substrate
+        runs in pure-stub mode : handler factories operate on
+        numpy tensors only, :meth:`awake` returns a canned string.
+        This keeps the module importable + testable on hosts
+        without Apple Silicon / the MLX wheel.
+    adapter_path
+        Optional path to a LoRA ``adapters.safetensors`` file (or
+        directory containing one). Loaded by :meth:`load` via
+        ``mlx_lm.load_adapters`` when present.
+    num_layers
+        Number of transformer layers the LoRA adapter targets.
+        Default 20 — matches the micro-kiki v4 default shape. Only
+        used to validate adapter-tensor shapes in the numpy
+        fallback path ; real MLX loading ignores this.
+    rank
+        LoRA rank. Default 16 (micro-kiki v4 SOTA spec). Used to
+        size stub adapter tensors in the numpy fallback path.
+    seed
+        Numpy RNG seed — controls any stochastic handler (recombine).
+
+    Attributes
+    ----------
+    mlx_lm_available
+        Informational bool mirroring the module-level probe.
+    """
+
+    base_model_path: str | None = None
+    adapter_path: str | None = None
+    num_layers: int = 20
+    rank: int = 16
+    seed: int = 0
+    mlx_lm_available: bool = field(default=_MLX_LM_AVAILABLE, init=False)
+    _model: Any = field(default=None, init=False, repr=False)
+    _tokenizer: Any = field(default=None, init=False, repr=False)
+    # Accumulator for the in-flight weight delta produced by the
+    # replay / downscale handlers. Stored as a plain ``dict`` keyed
+    # by the adapter weight-path (matches the shape emitted by
+    # ``mlx_lm.tuner.trainable_parameters``). Round-tripped by
+    # :meth:`snapshot` / :meth:`load_snapshot` as a numpy ``.npz``.
+    _current_delta: dict[str, NDArray] = field(
+        default_factory=dict, init=False, repr=False,
+    )
+    # DR-0 accountability state for the OPLoRA restructure handler
+    # (arXiv 2510.13003). Exposed read-only via :meth:`restructure_state`
+    # so the conformance harness can assert DR-1 (episode_id stamp
+    # consistency) without poking private attributes.
+    _restructure_state: MicroKikiRestructureState = field(
+        default_factory=MicroKikiRestructureState,
+        init=False,
+        repr=False,
+    )
+    _rng: np.random.Generator = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.num_layers <= 0:
+            raise ValueError(
+                f"num_layers must be > 0, got {self.num_layers}"
+            )
+        if self.rank <= 0:
+            raise ValueError(f"rank must be > 0, got {self.rank}")
+        self._rng = np.random.default_rng(self.seed)
+
+    # ----- lazy model / adapter load -----
+
+    def load(self) -> None:
+        """Load the base model + LoRA adapter via ``mlx_lm``.
+
+        No-op in stub mode (``base_model_path is None``). When
+        ``mlx_lm`` is unavailable we also short-circuit to stub
+        mode — this keeps the module importable on CI without an
+        Apple Silicon wheel. The real code path runs on Mac Studio
+        M3 Ultra where Qwen3.5-35B-A3B + LoRA adapter fit in the
+        460 GB Metal memory budget (see ``micro-kiki/CLAUDE.md``).
+        """
+        if self.base_model_path is None:
+            return
+        if not self.mlx_lm_available:  # pragma: no cover - env-gated
+            return
+        # pragma: no cover - env-gated (Apple Silicon only)
+        from mlx_lm import load as mlx_load
+        self._model, self._tokenizer = mlx_load(self.base_model_path)
+        if self.adapter_path is not None:
+            from mlx_lm.tuner.utils import (                load_adapters,
+            )
+
+            self._model = load_adapters(self._model, self.adapter_path)
+
+    # ----- awake-side generation -----
+
+    def awake(self, prompt: str, max_tokens: int = 32) -> str:
+        """Awake forward pass — returns generated text.
+
+        Stub path : returns ``f"[stub awake] {prompt}"`` so unit
+        tests can assert type + shape without an MLX wheel. Real
+        path (env-gated) dispatches to ``mlx_lm.generate`` with
+        the loaded model + tokenizer.
+        """
+        if self._model is None or self._tokenizer is None:
+            return f"[stub awake] {prompt}"
+        # pragma: no cover - env-gated (Apple Silicon only)
+        from mlx_lm import generate
+        return str(
+            generate(
+                self._model,
+                self._tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                verbose=False,
+            )
+        )
+
+    # ----- Protocol-contract factories (mirror esnn_* substrates) -----
+
+    def replay_handler_factory(
+        self,
+    ) -> Callable[[list[dict], int], NDArray]:
+        """A-Walker/Stickgold replay → LoRA gradient proxy.
+
+        Signature matches
+        ``esnn_thalamocortical.EsnnSubstrate.replay_handler_factory``
+        for DR-3 condition-1 uniformity : the handler takes a
+        ``beta_records: list[dict]`` + ``n_steps: int`` and
+        returns a 1-D numpy array. The stub aggregates each
+        record's ``"input"`` vector and returns the mean drive —
+        sufficient to exercise the swap + S1 retained-benchmark
+        path without an MLX device.
+        """
+
+        def handler(
+            beta_records: list[dict], n_steps: int = 20,
+        ) -> NDArray:
+            if not beta_records:
+                return np.zeros(1, dtype=np.float32)
+            vectors: list[NDArray] = [
+                np.asarray(r["input"], dtype=np.float32)
+                for r in beta_records
+                if "input" in r
+            ]
+            if not vectors:
+                return np.zeros(1, dtype=np.float32)
+            return np.asarray(
+                np.mean(np.stack(vectors), axis=0), dtype=np.float32,
+            )
+
+        return handler
+
+    def downscale_handler_factory(
+        self,
+    ) -> Callable[[NDArray, float], NDArray]:
+        """B-Tononi SHY → LoRA B-matrix multiplicative shrink.
+
+        Preserves DR-1 on the adapter state : the caller stamps
+        the returned tensor with ``episode_id`` via
+        ``kiki_oniric.dream.swap`` ; the handler itself only
+        performs the arithmetic. Commutative, not idempotent
+        (``f(f(w)) = w * factor²``). Matches the signature of
+        ``esnn_*`` substrate downscale handlers.
+        """
+
+        def handler(weights: NDArray, factor: float) -> NDArray:
+            if not (0.0 < factor <= 1.0):
+                raise ValueError(
+                    f"shrink_factor must be in (0, 1], got {factor}"
+                )
+            return (weights * factor).astype(weights.dtype, copy=False)
+
+        return handler
+
+    def restructure_handler_factory(
+        self,
+        rank_thresh: float = 1e-4,
+    ) -> Callable[[dict, str, str], dict]:
+        """D-Friston FEP restructure → **OPLoRA projection (phase 2)**.
+
+        Wires the Orthogonal-Projection LoRA algorithm of Du et
+        al. (arXiv 2510.13003) : given a list of prior-stack
+        adapter deltas carried on ``adapter["prior_deltas"]``, the
+        handler builds the projector ``P = I - U U^T`` onto the
+        orthogonal complement of the priors' range and replaces
+        the new adapter's B-matrix by ``P @ B_new``. The
+        contribution ``P · B_new · A_new · x`` is then orthogonal
+        to every prior range, preserving the S1 retained-benchmark
+        invariant across sequential stack additions.
+
+        Handler contract
+        ----------------
+        ``adapter`` is a mutable dict keyed by LoRA tensor name. It
+        *must* carry :
+
+        - ``"prior_deltas"`` : ``list[ndarray]`` of prior
+          ``B_i @ A_i`` products (shape ``(out_dim, in_dim_i)``).
+          Empty list means no priors to project away — handler
+          returns the adapter unchanged (no-op).
+        - ``key`` (the third positional arg) : name of the
+          B-matrix entry to project. Its shape must be
+          ``(out_dim, rank)`` with ``out_dim`` matching the
+          priors.
+        - Optional ``"episode_id"`` : DR-0 stamp propagated into
+          :attr:`_restructure_state`.
+
+        ``op`` is accepted for signature-compat with the phase-1
+        stub but currently only ``"oplora"`` is honoured (the
+        default). Any other value raises ``ValueError`` — keeps
+        the gate explicit per DR-3 condition-1 (no silent
+        no-ops).
+
+        Returns the same ``adapter`` dict (with the entry at
+        ``key`` replaced by ``P @ adapter[key]``).
+
+        Reference : Du et al., arXiv 2510.13003 §3.2-§3.3. The
+        local micro-kiki training pipeline at
+        ``src/stacks/oplora.py`` (torch) mirrors this algebra ;
+        this numpy port lives substrate-side for the dream
+        runtime's no-torch constraint.
+        """
+
+        def handler(
+            adapter: dict[str, NDArray], op: str, key: str,
+        ) -> dict[str, NDArray]:
+            if op not in {"oplora", "oplora_project", "project"}:
+                raise ValueError(
+                    f"micro_kiki.restructure_handler: unsupported "
+                    f"op {op!r} ; expected one of "
+                    f"{{'oplora', 'oplora_project', 'project'}}"
+                )
+            if key not in adapter:
+                raise KeyError(
+                    f"micro_kiki.restructure_handler: adapter "
+                    f"missing entry for key {key!r}"
+                )
+            new_B = np.asarray(adapter[key])
+            if new_B.ndim != 2:
+                raise ValueError(
+                    f"micro_kiki.restructure_handler: adapter[{key!r}] "
+                    f"must be 2-D (out_dim, rank), got shape "
+                    f"{new_B.shape}"
+                )
+
+            priors = list(adapter.get("prior_deltas", []))
+            episode_id = adapter.get("episode_id")
+
+            if priors:
+                P = _oplora_projector(priors, rank_thresh=rank_thresh)
+                if P.shape[0] != new_B.shape[0]:
+                    raise ValueError(
+                        f"micro_kiki.restructure_handler: projector "
+                        f"out_dim {P.shape[0]} != adapter[{key!r}] "
+                        f"out_dim {new_B.shape[0]}"
+                    )
+                projected = (P @ new_B.astype(np.float32)).astype(
+                    new_B.dtype, copy=False,
+                )
+                adapter[key] = projected
+                self._restructure_state.total_projections_applied += 1
+
+            # DR-0 bookkeeping : always bump the counter + record
+            # the episode (even when priors is empty — the op was
+            # invoked, and DR-0 credits every handler call, not
+            # just those with a non-trivial effect).
+            self._restructure_state.total_episodes_handled += 1
+            self._restructure_state.last_completed = True
+            self._restructure_state.last_operation = "restructure"
+            if isinstance(episode_id, str):
+                self._restructure_state.last_episode_id = episode_id
+                self._restructure_state.episode_ids.append(episode_id)
+            return adapter
+
+        return handler
+
+    @property
+    def restructure_state(self) -> MicroKikiRestructureState:
+        """Read-only accessor for the OPLoRA DR-0 record.
+
+        Exposed so the conformance harness (and unit tests) can
+        assert DR-0 (completed flag, operation label) + DR-1
+        (episode_id stamp propagation) without poking private
+        attributes. The returned object is the live state dataclass
+        — do not mutate ; it is refreshed by each handler call.
+        """
+        return self._restructure_state
+
+    def recombine_handler_factory(
+        self,
+    ) -> Callable[[NDArray, int, int], NDArray]:
+        """C-Hobson recombine → **phase-3 stub**.
+
+        Raises ``NotImplementedError`` : real implementation
+        requires a TIES-style merge (Yadav et al.,
+        *Resolving Interference When Merging Models*, arXiv
+        2306.01708) over a pair of per-domain LoRA adapters
+        (micro-kiki ships 32 experts). Merging two LoRAs is not
+        a raw latent interpolation ; the TIES sign-trim /
+        magnitude-elect procedure must be applied to respect the
+        downstream stack orthogonality guarantees. Deferred to
+        phase 3 — unblocks once the 32-expert curriculum
+        stabilises.
+        """
+
+        def handler(
+            latents: NDArray, seed: int = 0, n_steps: int = 10,
+        ) -> NDArray:
+            raise NotImplementedError(
+                "recombine_handler requires TIES-style LoRA merge "
+                "(Yadav et al., arXiv 2306.01708) — deferred to "
+                "phase 3 of the micro-kiki roadmap"
+            )
+
+        return handler
+
+    # ----- γ-snapshot : adapter round-trip -----
+
+    def snapshot(self, path: str | Path) -> Path:
+        """Persist the current accumulator delta to a ``.npz`` file.
+
+        Returns the written path. Round-trips cleanly via
+        :meth:`load_snapshot`. In a full MLX run the swap protocol
+        would instead serialise the LoRA adapter via
+        ``mlx_lm.utils.save_adapters`` to a ``.safetensors`` —
+        here we use numpy ``.npz`` for portability so the same
+        artifact format works on Linux CI.
+        """
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.suffix != ".npz":
+            target = target.with_suffix(".npz")
+        np.savez(target, **self._current_delta)
+        return target
+
+    def load_snapshot(self, path: str | Path) -> None:
+        """Restore the accumulator delta from a :meth:`snapshot` file."""
+        target = Path(path)
+        if not target.exists() and target.with_suffix(".npz").exists():
+            target = target.with_suffix(".npz")
+        data = np.load(target, allow_pickle=False)
+        self._current_delta = {k: np.asarray(data[k]) for k in data.files}
+
+
+def micro_kiki_substrate_components() -> dict[str, str]:
+    """Return the canonical map of micro-kiki substrate components.
+
+    Mirrors ``esnn_substrate_components`` + ``norse_substrate_components``
+    so the DR-3 Conformance Criterion test suite parametrizes over
+    the three substrates uniformly. Phase 2 lands the real
+    restructure + recombine backends ; the dotted paths stay
+    stable across that transition (the same module hosts both
+    the stub + the real impl).
+    """
+    return {
+        # 8 typed Protocols (substrate-agnostic, shared)
+        "primitives": "kiki_oniric.core.primitives",
+        # 4 operations — factory methods on this substrate class
+        "replay": "kiki_oniric.substrates.micro_kiki",
+        "downscale": "kiki_oniric.substrates.micro_kiki",
+        # phase-2 stubs, path stable across bump
+        "restructure": "kiki_oniric.substrates.micro_kiki",
+        "recombine": "kiki_oniric.substrates.micro_kiki",
+        # 2 invariant guards (substrate-agnostic, shared)
+        "finite": "kiki_oniric.dream.guards.finite",
+        "topology": "kiki_oniric.dream.guards.topology",
+        # Runtime + swap (substrate-agnostic, shared)
+        "runtime": "kiki_oniric.dream.runtime",
+        "swap": "kiki_oniric.dream.swap",
+        # 3 profiles (substrate-agnostic wrappers, shared)
+        "p_min": "kiki_oniric.profiles.p_min",
+        "p_equ": "kiki_oniric.profiles.p_equ",
+        "p_max": "kiki_oniric.profiles.p_max",
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreamofkiki"
-version = "0.8.0"
+version = "0.9.0"
 description = "Substrate-agnostic formal framework for dream-based knowledge consolidation"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -55,6 +55,10 @@ target-version = "py312"
 [tool.mypy]
 strict = true
 python_version = "3.12"
+
+[[tool.mypy.overrides]]
+module = ["mlx_lm", "mlx_lm.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conformance/axioms/test_dr3_micro_kiki_substrate.py
+++ b/tests/conformance/axioms/test_dr3_micro_kiki_substrate.py
@@ -1,0 +1,220 @@
+"""DR-3 Conformance Criterion — micro-kiki LoRA substrate (C2.5).
+
+Validates that the micro-kiki transformer-LoRA substrate satisfies
+the 3 conditions of DR-3 Conformance Criterion :
+
+1. Signature typing : substrate exports the expected Protocol-
+   compatible factories (callable + correct signatures).
+2. Axiom property tests : DR-0 accountability via restructure
+   bookkeeping ; DR-1 episode_id propagation ; OPLoRA orthogonality
+   property of the wired ``restructure`` op.
+3. BLOCKING invariants enforceable : S2 finite + S3 topology guards
+   operate on micro-kiki state representations (numpy LoRA deltas).
+
+The phase-3 ``recombine`` stub is exercised at the negative path
+(asserts the ``NotImplementedError`` surface stays honest) so the
+matrix entry stays visible in the cycle-3 conformance report.
+
+Reference: docs/specs/2026-04-17-dreamofkiki-framework-C-design.md §6.2
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kiki_oniric.dream.guards.finite import check_finite
+from kiki_oniric.dream.guards.topology import validate_topology
+from kiki_oniric.substrates.micro_kiki import (
+    MICRO_KIKI_SUBSTRATE_NAME,
+    MICRO_KIKI_SUBSTRATE_VERSION,
+    MicroKikiRestructureState,
+    MicroKikiSubstrate,
+    micro_kiki_substrate_components,
+)
+
+
+# ===== Condition 1: signature typing =====
+
+
+def test_c1_micro_kiki_exports_required_identity_constants() -> None:
+    """Substrate module exposes the canonical identity constants
+    expected by the substrate-agnostic harness.
+    """
+    assert MICRO_KIKI_SUBSTRATE_NAME == "micro_kiki"
+    assert MICRO_KIKI_SUBSTRATE_VERSION.startswith("C-v")
+    assert MICRO_KIKI_SUBSTRATE_VERSION.endswith("+PARTIAL")
+
+
+def test_c1_micro_kiki_substrate_instantiable_in_stub_mode() -> None:
+    """Instantiable on any host (CI Linux, Apple Silicon Mac).
+
+    No ``base_model_path`` → stub mode ; no MLX wheel required.
+    The conformance harness must be host-portable.
+    """
+    substrate = MicroKikiSubstrate()
+    assert substrate.base_model_path is None
+    assert substrate.restructure_state is not None
+    assert isinstance(substrate.restructure_state, MicroKikiRestructureState)
+
+
+def test_c1_micro_kiki_provides_4_op_factory_methods() -> None:
+    """All 4 op factories return callable handlers (DR-3 cond 1)."""
+    substrate = MicroKikiSubstrate()
+    assert callable(substrate.replay_handler_factory())
+    assert callable(substrate.downscale_handler_factory())
+    assert callable(substrate.restructure_handler_factory())
+    assert callable(substrate.recombine_handler_factory())
+
+
+def test_c1_micro_kiki_components_registry_mirrors_siblings() -> None:
+    """Components map shares the canonical core keys with the
+    sibling substrates so the harness can parametrize uniformly.
+    """
+    micro = micro_kiki_substrate_components()
+    core_keys = {
+        "primitives",
+        "replay", "downscale", "restructure", "recombine",
+        "finite", "topology",
+        "runtime", "swap",
+    }
+    assert core_keys <= set(micro.keys()), (
+        f"micro-kiki components missing core keys: "
+        f"{core_keys - set(micro.keys())}"
+    )
+
+
+# ===== Condition 2: axiom property tests =====
+
+
+def test_c2_micro_kiki_restructure_oplora_orthogonality() -> None:
+    """OPLoRA contract (paper §3.2) : the restructure op produces
+    a new B-matrix orthogonal to every prior delta column.
+
+    This is the substrate-side translation of DR-2 (compositionality
+    on the canonical order) : restructure produces an output that
+    safely composes with subsequent replay because the new adapter
+    no longer overlaps the prior subspace.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    rng = np.random.default_rng(7)
+    out_dim, rank = 8, 2
+    priors = [
+        rng.standard_normal((out_dim, 3)).astype(np.float32),
+        rng.standard_normal((out_dim, 4)).astype(np.float32),
+    ]
+    new_B = rng.standard_normal((out_dim, rank)).astype(np.float32)
+
+    adapter: dict = {
+        "B": new_B.copy(),
+        "prior_deltas": priors,
+    }
+    out = handler(adapter, "oplora", "B")
+    projected_B = out["B"]
+
+    for prior in priors:
+        cross = prior.T @ projected_B
+        np.testing.assert_allclose(
+            cross, np.zeros_like(cross), atol=1e-4,
+        )
+
+
+def test_c2_micro_kiki_restructure_dr0_accountability() -> None:
+    """DR-0 : every restructure execution increments the substrate's
+    accountability counters and stamps ``completed=True``.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    state_before = substrate.restructure_state
+    n_before = state_before.total_episodes_handled
+
+    out_dim = 4
+    prior = np.eye(out_dim, dtype=np.float32)[:, :2]
+    adapter: dict = {
+        "B": np.ones((out_dim, 2), dtype=np.float32),
+        "prior_deltas": [prior],
+    }
+    handler(adapter, "oplora", "B")
+
+    state_after = substrate.restructure_state
+    assert state_after.total_episodes_handled == n_before + 1
+    assert state_after.last_completed is True
+    assert state_after.last_operation == "restructure"
+
+
+def test_c2_micro_kiki_restructure_dr1_episode_stamp() -> None:
+    """DR-1 : an ``episode_id`` carried on the adapter is propagated
+    into the substrate's episodic state so the episode is
+    reconstructable downstream.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    out_dim = 4
+    prior = np.eye(out_dim, dtype=np.float32)[:, :2]
+    adapter: dict = {
+        "B": np.ones((out_dim, 2), dtype=np.float32),
+        "prior_deltas": [prior],
+        "episode_id": "ep-conformance-dr1",
+    }
+    handler(adapter, "oplora", "B")
+    state = substrate.restructure_state
+    assert "ep-conformance-dr1" in state.episode_ids
+    assert state.last_episode_id == "ep-conformance-dr1"
+
+
+def test_c2_micro_kiki_recombine_stub_surfaces_honestly() -> None:
+    """Phase-3 stub : ``recombine`` raises ``NotImplementedError``
+    rather than silently no-op'ing. The conformance matrix must
+    show this gap as a *visible* not-yet-backed cell.
+
+    When the TIES-merge backend lands this test gets replaced by a
+    positive contract test, mirroring the OPLoRA migration path.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    with pytest.raises(NotImplementedError, match="TIES"):
+        handler(np.zeros((2, 4), dtype=np.float32), seed=0, n_steps=1)
+
+
+# ===== Condition 3: BLOCKING invariants enforceable =====
+
+
+def test_c3_s2_finite_guard_works_on_micro_kiki_lora_delta() -> None:
+    """S2 invariant accepts valid LoRA delta tensors and rejects
+    NaN / Inf in the delta representation.
+    """
+    delta = np.zeros((8, 4), dtype=np.float32)
+    check_finite(delta)
+
+    bad = delta.copy()
+    bad[2, 1] = float("nan")
+    from kiki_oniric.dream.guards.finite import FiniteGuardError
+    with pytest.raises(FiniteGuardError):
+        check_finite(bad)
+
+
+def test_c3_s3_topology_guard_works_on_micro_kiki_topology() -> None:
+    """S3 topology validator (substrate-agnostic) accepts the
+    canonical ortho chain and rejects a self-loop. Confirms the
+    micro-kiki substrate participates in the same topology contract
+    as the sibling substrates.
+    """
+    canonical = {
+        "rho_phono": ["rho_lex"],
+        "rho_lex": ["rho_syntax"],
+        "rho_syntax": ["rho_sem"],
+        "rho_sem": [],
+    }
+    validate_topology(canonical)
+
+    bad = {
+        "rho_phono": ["rho_phono"],
+        "rho_lex": ["rho_syntax"],
+        "rho_syntax": ["rho_sem"],
+        "rho_sem": [],
+    }
+    from kiki_oniric.dream.guards.topology import TopologyGuardError
+    with pytest.raises(TopologyGuardError):
+        validate_topology(bad)

--- a/tests/unit/test_micro_kiki_restructure.py
+++ b/tests/unit/test_micro_kiki_restructure.py
@@ -1,0 +1,320 @@
+"""OPLoRA restructure tests — micro-kiki substrate, cycle-3 phase 2.
+
+Covers the OPLoRA projection wired into
+:meth:`MicroKikiSubstrate.restructure_handler_factory` (arXiv
+2510.13003, Du et al.). The paper's key invariants and the dream
+runtime's DR-0 / DR-1 axioms are asserted in parallel :
+
+- *Algebra* (paper §3.2) : ``P @ v = 0`` for ``v`` in the prior
+  subspace ; ``P @ w = w`` for ``w`` in its orthogonal
+  complement ; ``P`` is symmetric idempotent (``P @ P ≈ P``).
+- *DR-0* (accountability) : every handler call bumps the
+  ``restructure_state`` counters ; ``completed=True`` and
+  ``operation='restructure'`` are recorded.
+- *DR-1* (episodic stamp) : an ``episode_id`` carried on the
+  adapter dict is propagated to ``state.last_episode_id`` and
+  appended to ``state.episode_ids``.
+
+These tests are numpy-only and run on any host (no MLX / torch
+dep). Reference :
+``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md`` §6.2
+(DR-0, DR-1, DR-3).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kiki_oniric.substrates.micro_kiki import (
+    MicroKikiRestructureState,
+    MicroKikiSubstrate,
+    _oplora_projector,
+)
+
+
+# ---------------------------------------------------------------
+# _oplora_projector — pure-function algebra
+# ---------------------------------------------------------------
+
+
+def test_projector_orthogonality() -> None:
+    """Projector annihilates every column of every prior delta.
+
+    Paper §3.2 : ``P = I - U U^T`` where ``U`` spans the column
+    space of the stacked priors ; therefore ``P @ v = 0`` for
+    any ``v`` that lies in that span — in particular, every
+    column of every prior delta.
+    """
+    rng = np.random.default_rng(7)
+    out_dim = 8
+    priors = [
+        rng.standard_normal((out_dim, 3)).astype(np.float32),
+        rng.standard_normal((out_dim, 2)).astype(np.float32),
+    ]
+    P = _oplora_projector(priors)
+    assert P.shape == (out_dim, out_dim)
+    for prior in priors:
+        projected = P @ prior
+        np.testing.assert_allclose(
+            projected, np.zeros_like(projected), atol=1e-5,
+        )
+
+
+def test_projector_preserves_orthogonal_complement() -> None:
+    """Vectors orthogonal to the prior subspace pass through unchanged.
+
+    Construct a small prior whose column space is exactly
+    ``span(e_0, e_1)`` ; pick ``w = e_3`` which is orthogonal to
+    that span ; assert ``P @ w ≈ w``.
+    """
+    out_dim = 6
+    prior = np.zeros((out_dim, 2), dtype=np.float32)
+    prior[0, 0] = 1.0  # column 0 == e_0
+    prior[1, 1] = 1.0  # column 1 == e_1
+    P = _oplora_projector([prior])
+
+    w = np.zeros(out_dim, dtype=np.float32)
+    w[3] = 1.0
+    np.testing.assert_allclose(P @ w, w, atol=1e-6)
+
+    # ``P`` is symmetric.
+    np.testing.assert_allclose(P, P.T, atol=1e-6)
+    # Idempotent : ``P @ P == P``.
+    np.testing.assert_allclose(P @ P, P, atol=1e-5)
+
+
+def test_projector_shape_mismatch_raises() -> None:
+    """Different ``out_dim`` across priors is a caller bug."""
+    p1 = np.zeros((4, 2), dtype=np.float32)
+    p2 = np.zeros((5, 2), dtype=np.float32)
+    with pytest.raises(ValueError, match="out_dim"):
+        _oplora_projector([p1, p2])
+
+
+def test_projector_empty_priors_rejected() -> None:
+    """Empty prior list → explicit error (caller handles the no-op).
+
+    The handler path treats empty priors as a DR-0-credited no-op,
+    but the pure helper is stricter : it must see at least one
+    prior so the fallback semantics stay visible to callers.
+    """
+    with pytest.raises(ValueError, match="at least one"):
+        _oplora_projector([])
+
+
+def test_projector_rank_collapse_falls_back_to_identity() -> None:
+    """All singular values below ``rank_thresh`` → ``P = I``.
+
+    Paper §3.3 robustness study : if the priors degenerate to
+    numerical noise the projector collapses to identity (i.e.
+    we refuse to over-prune a meaningful new adapter based on
+    noise).
+    """
+    out_dim = 4
+    # Near-zero prior ; every singular value below the default
+    # threshold of 1e-4.
+    prior = np.full((out_dim, 2), 1e-8, dtype=np.float32)
+    P = _oplora_projector([prior], rank_thresh=1e-4)
+    np.testing.assert_allclose(
+        P, np.eye(out_dim, dtype=np.float32), atol=1e-6,
+    )
+
+
+# ---------------------------------------------------------------
+# restructure_handler_factory — DR-0 / DR-1 contract
+# ---------------------------------------------------------------
+
+
+def test_restructure_handler_callable() -> None:
+    """Factory returns a callable (DR-3 condition 1)."""
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    assert callable(handler)
+    # Factory also returns a fresh state container.
+    assert isinstance(substrate.restructure_state, MicroKikiRestructureState)
+
+
+def test_restructure_consumes_episode_projects_new_B() -> None:
+    """End-to-end : 2 priors + 1 new B-matrix ⇒ projected B is
+    orthogonal to every prior range, adapter dict mutated in
+    place, DR-0 counters bumped.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    rng = np.random.default_rng(42)
+    out_dim = 8
+    rank = 2
+    priors = [
+        rng.standard_normal((out_dim, 3)).astype(np.float32),
+        rng.standard_normal((out_dim, 4)).astype(np.float32),
+    ]
+    # Intentionally pick a new B-matrix NOT orthogonal to priors —
+    # the projection must move it.
+    new_B_original = rng.standard_normal((out_dim, rank)).astype(np.float32)
+
+    adapter: dict = {
+        "layers.5.q_proj_B": new_B_original.copy(),
+        "prior_deltas": priors,
+        "episode_id": "ep-restruct-42",
+    }
+    out = handler(adapter, "oplora", "layers.5.q_proj_B")
+
+    projected_B = out["layers.5.q_proj_B"]
+    # Shape + dtype preserved.
+    assert projected_B.shape == new_B_original.shape
+    assert projected_B.dtype == new_B_original.dtype
+
+    # Projected-B columns orthogonal to every prior-delta column.
+    for prior in priors:
+        cross = prior.T @ projected_B
+        np.testing.assert_allclose(
+            cross, np.zeros_like(cross), atol=1e-4,
+        )
+
+    # The projection was non-trivial (new_B wasn't already in the
+    # orthogonal complement). Sanity check the test setup.
+    assert not np.allclose(projected_B, new_B_original, atol=1e-3)
+
+    # DR-0 bookkeeping — completed flag, operation label, counters.
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 1
+    assert state.last_completed is True
+    assert state.last_operation == "restructure"
+
+
+def test_restructure_dr1_episode_id_stamping() -> None:
+    """DR-1 — every episode_id carried on the adapter dict lands
+    on the state in order ; unstamped calls skip the append but
+    still bump the counter.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    rng = np.random.default_rng(1)
+    out_dim = 4
+    prior = rng.standard_normal((out_dim, 2)).astype(np.float32)
+    B0 = rng.standard_normal((out_dim, 2)).astype(np.float32)
+
+    for eid in ("e0", "e1", "e2"):
+        adapter: dict = {
+            "B": B0.copy(),
+            "prior_deltas": [prior],
+            "episode_id": eid,
+        }
+        handler(adapter, "oplora", "B")
+
+    # Unstamped call — state.last_episode_id sticks at "e2",
+    # episode_ids list not appended, counter bumped.
+    handler(
+        {"B": B0.copy(), "prior_deltas": [prior]},
+        "oplora",
+        "B",
+    )
+
+    state = substrate.restructure_state
+    assert state.episode_ids == ["e0", "e1", "e2"]
+    assert state.last_episode_id == "e2"
+    assert state.total_episodes_handled == 4
+    assert state.total_projections_applied == 4
+
+
+def test_restructure_empty_priors_is_dr0_noop() -> None:
+    """Empty ``prior_deltas`` — handler is a DR-0-credited no-op.
+
+    The adapter dict is returned unchanged (no projection applied)
+    but the episode is still recorded : DR-0 credits every
+    handler invocation, even those with no net effect on the
+    adapter tensors. ``total_projections_applied`` stays at 0 so
+    callers can audit the no-op leg.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    B = np.ones((3, 2), dtype=np.float32)
+    adapter: dict = {
+        "B": B.copy(),
+        "prior_deltas": [],
+        "episode_id": "ep-noop",
+    }
+    out = handler(adapter, "oplora", "B")
+    np.testing.assert_array_equal(out["B"], B)
+
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 0
+    assert state.last_episode_id == "ep-noop"
+    assert state.last_completed is True
+
+
+def test_restructure_rejects_wrong_op() -> None:
+    """DR-3 condition 1 : unknown op-names fail loud.
+
+    Silent fallbacks would mask dispatcher bugs in the
+    conformance harness ; the handler only honours the OPLoRA
+    op vocabulary.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    adapter = {"B": np.zeros((2, 2), dtype=np.float32), "prior_deltas": []}
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler(adapter, "merge", "B")
+
+
+def test_restructure_rejects_missing_key() -> None:
+    """Missing B-matrix key → explicit KeyError.
+
+    Pairs with the op-vocabulary guard above : caller bugs surface
+    at the handler boundary, not as a downstream shape mismatch.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    adapter: dict = {"prior_deltas": []}
+    with pytest.raises(KeyError, match="missing entry"):
+        handler(adapter, "oplora", "does_not_exist")
+
+
+def test_restructure_rejects_projector_shape_mismatch() -> None:
+    """Prior out_dim ≠ new-B out_dim is a caller bug ; raise."""
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+
+    prior = np.ones((5, 2), dtype=np.float32)  # out_dim = 5
+    new_B = np.ones((4, 2), dtype=np.float32)  # out_dim = 4
+    adapter: dict = {
+        "B": new_B,
+        "prior_deltas": [prior],
+    }
+    with pytest.raises(ValueError, match="out_dim"):
+        handler(adapter, "oplora", "B")
+
+
+def test_projector_full_rank_saturation_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When priors span the full output space the projector
+    collapses to zero ; the helper must emit a warning so the
+    silent zeroing of new adapters is auditable.
+
+    This is the operational gotcha of long sequential curricula
+    — each new expert adds rank to the prior subspace and after
+    enough experts the union saturates ``out_dim``. OPLoRA does
+    not claim to handle this case (the math is correct, ``P = 0``
+    *is* the orthogonal projector onto the empty complement) but
+    the missing warning would otherwise let the regression slip
+    by undetected.
+    """
+    out_dim = 4
+    # ``out_dim`` independent unit vectors → range == R^out_dim,
+    # complement is empty, projector is the zero matrix.
+    prior = np.eye(out_dim, dtype=np.float32)
+    with caplog.at_level("WARNING", logger="kiki_oniric.substrates.micro_kiki"):
+        P = _oplora_projector([prior])
+    np.testing.assert_allclose(
+        P, np.zeros((out_dim, out_dim), dtype=np.float32), atol=1e-6,
+    )
+    assert any(
+        "projector is effectively zero" in rec.message
+        for rec in caplog.records
+    ), f"Expected saturation warning ; got {[r.message for r in caplog.records]}"

--- a/tests/unit/test_micro_kiki_substrate.py
+++ b/tests/unit/test_micro_kiki_substrate.py
@@ -1,0 +1,212 @@
+"""Unit tests for the micro-kiki substrate (cycle-3 Phase 2 draft).
+
+These tests must run WITHOUT ``mlx_lm`` / ``mlx`` installed — the
+substrate falls back to a numpy path when the MLX wheel is not
+importable, so the unit tests cover the fallback leg
+deterministically. A true ``mlx_lm`` execution is env-gated to
+Apple Silicon hosts (matches the ``esnn_norse`` pattern).
+
+Reference : ``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md``
+§6.2 (DR-3 Conformance Criterion).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kiki_oniric.substrates.micro_kiki import (
+    MICRO_KIKI_SUBSTRATE_NAME,
+    MICRO_KIKI_SUBSTRATE_VERSION,
+    MicroKikiSubstrate,
+    micro_kiki_substrate_components,
+)
+
+
+def test_module_manifest_matches_substrate_pattern() -> None:
+    """TDD-1 — module-level identity + manifest shape align with
+    the sibling ``esnn_*`` substrates (DR-3 condition 1).
+    """
+    assert MICRO_KIKI_SUBSTRATE_NAME == "micro_kiki"
+    assert MICRO_KIKI_SUBSTRATE_VERSION == "C-v0.8.0+PARTIAL"
+
+    components = micro_kiki_substrate_components()
+    expected = {
+        "primitives",
+        "replay", "downscale", "restructure", "recombine",
+        "finite", "topology",
+        "runtime", "swap",
+        "p_min", "p_equ", "p_max",
+    }
+    assert set(components.keys()) == expected
+    # All dotted paths live under kiki_oniric — no micro-kiki-side
+    # module leaks into the upstream manifest.
+    for value in components.values():
+        assert value.startswith("kiki_oniric."), value
+
+
+def test_replay_handler_is_callable_and_aggregates_inputs() -> None:
+    """TDD-2 — replay factory returns a callable ; the callable
+    aggregates beta-record ``input`` vectors (mean drive). Exercises
+    the empty-records + malformed-records + nominal branches.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.replay_handler_factory()
+
+    assert callable(handler)
+    # Empty + malformed : return 1-element zero vector (stable shape
+    # contract shared with esnn_norse for the DR-3 matrix).
+    assert handler([], n_steps=5).shape == (1,)
+    assert handler([{"other": 1.0}], n_steps=5).shape == (1,)
+
+    # Nominal : mean of two 4-D inputs.
+    records = [
+        {"input": [1.0, 0.0, 0.0, 0.0]},
+        {"input": [0.0, 1.0, 0.0, 0.0]},
+    ]
+    out = handler(records, n_steps=4)
+    assert out.shape == (4,)
+    np.testing.assert_allclose(out, [0.5, 0.5, 0.0, 0.0])
+    # dtype contract : float32 aligns with LoRA adapter storage
+    assert out.dtype == np.float32
+
+
+def test_downscale_preserves_shape_and_rejects_invalid_factor() -> None:
+    """TDD-3 — downscale returns ``weights * factor`` with the
+    input dtype preserved (so the LoRA adapter round-trips without
+    a float64 bloat). The factor must lie in (0, 1] — mirrors the
+    esnn_thalamocortical / esnn_norse contract so the DR-3 test
+    matrix can parametrize. Matrix-preservation is what episode-id
+    stamping (DR-1) binds to downstream.
+    """
+    substrate = MicroKikiSubstrate(rank=8, num_layers=4, seed=0)
+    handler = substrate.downscale_handler_factory()
+
+    weights = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    shrunk = handler(weights, factor=0.99)
+    # Shape + dtype preserved — caller can stamp episode_id on the
+    # same tensor object without re-casting.
+    assert shrunk.shape == weights.shape
+    assert shrunk.dtype == weights.dtype
+    np.testing.assert_allclose(shrunk, weights * 0.99, rtol=1e-6)
+
+    # Out-of-range factors rejected so the S1 retained-benchmark
+    # guard can trust the downscale arithmetic (a factor > 1 would
+    # amplify, a factor <= 0 would zero / flip the adapter).
+    with pytest.raises(ValueError, match="shrink_factor"):
+        handler(weights, factor=0.0)
+    with pytest.raises(ValueError, match="shrink_factor"):
+        handler(weights, factor=1.5)
+
+
+def test_restructure_handler_oplora_wired() -> None:
+    """TDD-4 (phase-2) — restructure factory returns an OPLoRA-
+    backed callable (arXiv 2510.13003). Empty ``prior_deltas``
+    is a DR-0-credited no-op ; the full algebra is exercised in
+    ``tests/unit/test_micro_kiki_restructure.py``.
+
+    The phase-1 ``NotImplementedError`` gate is retired here in
+    favour of an assertion that the op is *wired* ; the gate is
+    now covered by the dedicated OPLoRA test module so the DR-3
+    conformance harness sees the real surface, not a stub.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.restructure_handler_factory()
+    assert callable(handler)
+
+    adapter: dict = {
+        "layers.0.q_proj_B": np.zeros((4, 2), dtype=np.float32),
+        "prior_deltas": [],  # empty → no-op projection leg
+        "episode_id": "ep-restruct-0",
+    }
+    out = handler(adapter, "oplora", "layers.0.q_proj_B")
+    # No priors → adapter entry unchanged ; state still bumped.
+    np.testing.assert_array_equal(
+        out["layers.0.q_proj_B"], np.zeros((4, 2), dtype=np.float32),
+    )
+    state = substrate.restructure_state
+    assert state.total_episodes_handled == 1
+    assert state.total_projections_applied == 0
+    assert state.last_completed is True
+    assert state.last_operation == "restructure"
+    assert state.last_episode_id == "ep-restruct-0"
+
+    # Unsupported op still rejected — DR-3 visibility.
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler(adapter, "activate", "layers.0.q_proj_B")
+
+
+def test_recombine_raises_phase_2() -> None:
+    """TDD-5 — recombine factory returns a callable that raises
+    ``NotImplementedError`` with an explicit TIES-merge citation.
+    Paired with restructure above — both phase-2 stubs must be
+    discoverable by the DR-3 conformance matrix as *callable*
+    but *deliberately un-backed* surfaces.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    assert callable(handler)
+    latents = np.array([[0.5, 0.2], [0.1, 0.8]], dtype=np.float32)
+    with pytest.raises(NotImplementedError, match="TIES"):
+        handler(latents, seed=0)
+
+
+def test_stub_mode_without_mlx_lm(tmp_path: Path) -> None:
+    """TDD-6 — the substrate builds + exposes its full Protocol
+    surface without any ``mlx_lm`` / ``mlx`` wheel installed.
+
+    This is the CI leg — dream-of-kiki ships an Apple-Silicon-only
+    MLX dep ; the Linux runners exercise the fallback path. The
+    test also confirms :meth:`load` is a safe no-op in stub mode
+    and the snapshot / load_snapshot round-trip works over the
+    numpy ``.npz`` accumulator.
+    """
+    substrate = MicroKikiSubstrate(base_model_path=None)
+    # mlx_lm_available is whatever the module-level probe saw — we
+    # don't assert a specific value, only that it's a bool so
+    # callers can introspect without a try-import.
+    assert isinstance(substrate.mlx_lm_available, bool)
+
+    # Stub awake — deterministic, no model loaded.
+    assert substrate.awake("hello") == "[stub awake] hello"
+
+    # load() is a safe no-op when base_model_path is None.
+    substrate.load()  # must not raise
+    assert substrate._model is None
+    assert substrate._tokenizer is None
+
+    # snapshot / load_snapshot round-trip over an empty accumulator.
+    snap_path = tmp_path / "micro-kiki-delta.npz"
+    written = substrate.snapshot(snap_path)
+    assert written.exists()
+    assert written.suffix == ".npz"
+
+    # Populate the accumulator, round-trip through disk.
+    substrate._current_delta = {
+        "layers.0.lora_A": np.ones((8, 4), dtype=np.float32),
+        "layers.0.lora_B": np.zeros((4, 8), dtype=np.float32),
+    }
+    written = substrate.snapshot(tmp_path / "delta2")  # no .npz suffix
+    assert written.exists()
+    substrate._current_delta = {}
+    substrate.load_snapshot(written)
+    assert set(substrate._current_delta.keys()) == {
+        "layers.0.lora_A", "layers.0.lora_B",
+    }
+    np.testing.assert_array_equal(
+        substrate._current_delta["layers.0.lora_A"],
+        np.ones((8, 4), dtype=np.float32),
+    )
+
+
+def test_invalid_config_rejected() -> None:
+    """TDD-7 — guard ctor args : ``num_layers`` and ``rank`` must
+    be positive. Zero / negative values are caught at construction
+    so downstream shape / LoRA-rank invariants hold without extra
+    checks in the handlers.
+    """
+    with pytest.raises(ValueError, match="num_layers"):
+        MicroKikiSubstrate(num_layers=0)
+    with pytest.raises(ValueError, match="rank"):
+        MicroKikiSubstrate(rank=-1)

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "dreamofkiki"
-version = "0.1.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Third substrate for framework C, wrapping the
[`micro-kiki`](https://github.com/kxkm-ai/micro-kiki) project's Qwen
MoE + LoRA adapter training output. Extends the DR-3 Conformance
Criterion surface from 2 substrates (MLX kiki-oniric + E-SNN
thalamocortical/Norse) to 3, adding a transformer-LoRA leg
alongside the SNN legs.

**Squash of prior work** : this PR consolidates the substrate
scaffold (originally PR #9) and the OPLoRA `restructure_handler`
backing (originally PR #10) into a single atomic commit. The
intermediate `NotImplementedError` stub for `restructure` never
lands on `main`, keeping bisect-friendly history and avoiding two
back-to-back DualVer bumps.

## Scope

**Handlers backed (3/4)**
- `replay_handler_factory` + `downscale_handler_factory` — numpy
  (CI) and `mlx_lm` (Apple Silicon, env-gated) paths.
- `restructure_handler_factory` — OPLoRA (Du et al., arXiv
  2510.13003). Projects new adapter deltas onto the orthogonal
  complement of the prior subspace via numpy SVD. Helper
  `_oplora_projector(prior_deltas, rank_thresh=1e-4)` with explicit
  guards (empty priors reject, shape-mismatch raises, rank-collapse
  fallback to identity with warning). Read-only
  `MicroKikiRestructureState` records DR-0 + DR-1 stamps.

**Phase-2 stub (1/4)**
- `recombine_handler_factory` (TIES-merge, Yadav et al.) raises
  `NotImplementedError` with explicit citation. Surfaced rather
  than silently no-op'd. Follow-up PR once the 32-expert curriculum
  stabilises.

**Persistence**
- `snapshot` / `load_snapshot` round-trip the accumulator delta via
  numpy `.npz` (portable across the 3-substrate test matrix).

## DualVer

- Repo : `0.8.0` → `0.9.0` (FC-MINOR — new public substrate
  surface, no semantic change to existing axioms).
- Substrate-internal : `C-v0.7.0+PARTIAL` → `C-v0.8.0+PARTIAL` (3/4
  handlers backed). `+PARTIAL` retained because `recombine` stub
  remains.

CHANGELOG entry under `[C-v0.9.0+PARTIAL] — 2026-04-22`.

## Test plan

- [x] `pytest tests/unit/test_micro_kiki_substrate.py` — 7/7 pass.
- [x] `pytest tests/unit/test_micro_kiki_restructure.py` — 12/12 pass.
- [x] `pytest tests/unit/` (full unit suite) — 289 passed, zero
      regressions.
- [x] `ruff check` on touched files — clean.
- [ ] Phase 4 : `dream-harness conformance --substrate micro_kiki`
      on Apple-Silicon host. Blocked on `recombine` landing + a real
      model checkpoint fitting the harness budget.

## Follow-up (not in scope)

1. `recombine_handler_factory` via TIES-merge once micro-kiki
   Stack 4 graduates (separate PR → `C-v0.10.0+PARTIAL`).
2. Full conformance run once (1) lands → flip substrate version
   to `C-v0.X.X+STABLE` once H1-H6 are green.
3. `scripts/ablation_cycle3.py` extension to include the
   `micro_kiki` substrate axis in the cartesian.

## Supersedes

- Closes #9 (substrate scaffold — squashed into this PR).
- Closes #10 (OPLoRA restructure — squashed into this PR).