### PR TITLE
feat(micro-kiki): TIES recombine handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,68 @@ see `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12).
 
 ## [C-v0.9.0+PARTIAL] — 2026-04-22
 
+### Added — micro-kiki recombine TIES-Merge (FC-MINOR bump, repo 0.9.0 → 0.10.0)
+
+Fourth (and last) handler on the micro-kiki substrate now backed.
+`recombine_handler_factory` replaces its phase-1
+`NotImplementedError` stub with a numpy port of TIES-Merge
+(Yadav et al., arXiv 2306.01708) : trim → elect-sign →
+disjoint-mean merge on a list of task-specific delta tensors.
+
+**Helper**
+
+- `_ties_merge(deltas, trim_fraction=0.2, alpha=1.0)` —
+  substrate-internal helper. Guards : empty list raises, single
+  delta fast-paths to `alpha * delta`, shape-mismatch across
+  deltas raises, `trim_fraction` outside `(0, 1]` raises.
+  Algebra in float64, output cast back to input dtype.
+
+**Handler contract**
+
+- Takes `(payload: dict, op: str = "ties") -> ndarray`. Payload
+  must carry `"deltas": list[ndarray]` ; optional `"episode_id"`
+  lands on the DR-1 stamp. Honours `op ∈ {"ties", "ties_merge",
+  "merge"}` ; any other op raises `ValueError` (DR-3 condition 1,
+  no silent no-ops).
+- New `MicroKikiRecombineState` dataclass exposed read-only via
+  `MicroKikiSubstrate.recombine_state`. Stamps DR-0 (completed
+  flag + operation label + counters) and DR-1 (episode_id list).
+  Records `last_k_deltas`, `last_input_shape`, `last_output_shape`
+  per call so the conformance harness can audit shape consistency.
+
+**Substrate-internal version**
+
+- `MICRO_KIKI_SUBSTRATE_VERSION` bumped `C-v0.8.0+PARTIAL` →
+  `C-v0.9.0+PARTIAL`. All 4 handlers (replay / downscale /
+  restructure / recombine) now backed by a real algorithm ;
+  `+PARTIAL` retained until the Phase-4 conformance run lands.
+
+**Tests**
+
+- New `tests/unit/test_micro_kiki_recombine.py` — 14 unit tests :
+  `_ties_merge` algebra (single-delta fast-path, two-delta sign
+  consensus, three-delta election, regression against
+  hand-computed example, trim-halves check), guard tests
+  (shape-mismatch, empty-list, invalid trim_fraction), handler
+  contract (callable + fresh state, DR-0 + DR-1 stamping on
+  multi-call, unknown-op rejection, missing-deltas-key
+  rejection, empty-deltas error propagation), snapshot /
+  load_snapshot round-trip with accumulator seeded from a real
+  merged delta.
+- `tests/unit/test_micro_kiki_substrate.py` : retired the
+  `test_recombine_raises_phase_2` `NotImplementedError` gate in
+  favour of a wired-assertion smoke test ; updated the
+  version-manifest assertion to `C-v0.9.0+PARTIAL`.
+
+**DualVer**
+
+- Repo `0.9.0` → `0.10.0` (pyproject.toml) — FC-MINOR, new
+  public handler surface (recombine backed).
+- Framework axis stays at `C-v0.9.0+PARTIAL` ; this completes
+  the phase-2 work started with the OPLoRA restructure landing.
+
+## [C-v0.9.0+PARTIAL micro-kiki substrate initial add] — 2026-04-22
+
 ### Added — micro-kiki LoRA substrate (FC-MINOR bump)
 
 Third substrate for framework C, wrapping the

--- a/kiki_oniric/substrates/micro_kiki.py
+++ b/kiki_oniric/substrates/micro_kiki.py
@@ -29,9 +29,11 @@ Phase boundaries (explicit) :
   tensors, restructure + recombine stubbed with an explicit
   ``NotImplementedError`` citing the blocker.
 - **Phase 2 (this file)** : OPLoRA projection wired in
-  (restructure ; arXiv 2510.13003 Du et al.) ; TIES-style merge
-  (recombine) still stubbed, lands once the 32-expert curriculum
-  stabilises.
+  (restructure ; arXiv 2510.13003 Du et al.) + TIES-Merge wired
+  in (recombine ; arXiv 2306.01708 Yadav et al.). All 4 handlers
+  now backed ; +PARTIAL retained until the Phase-4 conformance
+  harness lands (no downgrade on the EC axis while Phase-3
+  cross-substrate ablation is in flight).
 - **Phase 3** : swap / eval_retained bindings + cross-substrate
   ablation (cycle-3 G10 Gate D).
 """
@@ -49,13 +51,13 @@ from numpy.typing import NDArray
 _LOG = logging.getLogger(__name__)
 
 
-# DualVer C-v0.8.0+PARTIAL — restructure (OPLoRA) wired ; recombine
-# (TIES-merge) remains the only stub. Aligned to the sibling cycle-3
-# substrates (``esnn_thalamocortical`` + ``esnn_norse``). Phase 2
-# completion (recombine real backend) will bump EC axis only ; the
-# formal axis tracks upstream framework-C spec changes.
+# DualVer C-v0.9.0+PARTIAL — recombine (TIES-Merge, arXiv 2306.01708)
+# wired in ; all 4 handlers now backed. Retained ``+PARTIAL`` until
+# Phase-4 conformance harness confirms DR-2 / DR-4 across the
+# 3-substrate matrix. Aligned to the sibling cycle-3 substrates
+# (``esnn_thalamocortical`` + ``esnn_norse``).
 MICRO_KIKI_SUBSTRATE_NAME = "micro_kiki"
-MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.8.0+PARTIAL"
+MICRO_KIKI_SUBSTRATE_VERSION = "C-v0.9.0+PARTIAL"
 
 
 # -----------------------------------------------------------------
@@ -223,6 +225,179 @@ class MicroKikiRestructureState:
     last_completed: bool = False
     episode_ids: list[str] = field(default_factory=list)
 
+
+# -----------------------------------------------------------------
+# TIES-Merge (Yadav et al., arXiv 2306.01708, §3)
+# -----------------------------------------------------------------
+# Given ``K`` task-specific delta tensors ``τ_i = W_ft_i - W_base``
+# (sharing a common shape), TIES-Merge produces a single merged
+# delta via a three-step procedure :
+#
+#   1. **Trim** : per task ``i``, zero the ``(1 - k)%`` smallest-
+#      magnitude entries of ``τ_i``. Keeps only the top-``k``
+#      fraction by absolute value — reduces "sign-noise"
+#      interference from parameters the task barely updated.
+#   2. **Elect sign** : per parameter ``p`` compute the sign of
+#      the sum of signed magnitudes across tasks,
+#      ``γ_p = sign(Σ_i sign(τ_i[p]) · |τ_i[p]|)``. Parameters
+#      with no consensus end up at ``γ = 0`` and contribute zero
+#      to the merged delta.
+#   3. **Disjoint merge** : per parameter, take the mean over only
+#      those tasks whose sign agrees with ``γ_p``. Parameters with
+#      ``γ = 0`` or no agreeing tasks remain ``0``.
+#
+# The merged delta is finally scaled by a merge coefficient
+# ``alpha`` (default 1.0 — paper §3 default ; larger values
+# amplify the merged contribution when downstream eval suggests
+# under-shooting).
+#
+# Numpy-only port so the dream runtime stays torch / mlx free.
+# -----------------------------------------------------------------
+
+
+def _ties_merge(
+    deltas: list[NDArray],
+    trim_fraction: float = 0.2,
+    alpha: float = 1.0,
+) -> NDArray:
+    """Merge a list of task-specific delta tensors via TIES-Merge.
+
+    Parameters
+    ----------
+    deltas
+        Non-empty list of per-task delta tensors. All must share
+        the same shape ; shape-mismatch raises ``ValueError``.
+    trim_fraction
+        Fraction of entries to **keep** per task (top-magnitude
+        quantile). Default ``0.2`` matches the paper's k=20 %.
+        Must lie in ``(0, 1]``.
+    alpha
+        Merge coefficient scaling the final delta. Default ``1.0``
+        — the paper's unscaled merge.
+
+    Returns
+    -------
+    merged : ndarray
+        Same shape as each input delta ; dtype of the first input.
+
+    Raises
+    ------
+    ValueError
+        - Empty ``deltas`` list.
+        - Shape-mismatch across inputs.
+        - ``trim_fraction`` outside ``(0, 1]``.
+
+    Notes
+    -----
+    Single-element input fast-paths to ``alpha * deltas[0]`` — no
+    election / trimming needed when only one task contributes.
+
+    Reference : Yadav et al., *TIES-Merging : Resolving
+    Interference When Merging Models*, arXiv 2306.01708, §3
+    (procedure) + §4 (empirical defaults).
+    """
+    if not deltas:
+        raise ValueError(
+            "TIES-Merge _ties_merge requires at least one delta ; "
+            "got empty list"
+        )
+    if not (0.0 < trim_fraction <= 1.0):
+        raise ValueError(
+            f"trim_fraction must lie in (0, 1], got {trim_fraction}"
+        )
+
+    first = np.asarray(deltas[0])
+    target_dtype = first.dtype
+    target_shape = first.shape
+
+    if len(deltas) == 1:
+        # Single-task fast path : no election / trim needed.
+        return (alpha * first.astype(np.float64)).astype(
+            target_dtype, copy=False,
+        )
+
+    for i, d in enumerate(deltas):
+        arr = np.asarray(d)
+        if arr.shape != target_shape:
+            raise ValueError(
+                f"TIES-Merge: all deltas must share shape "
+                f"{target_shape}, got {arr.shape} at index {i}"
+            )
+
+    # Stack into shape (K, *delta_shape) in float64 for a stable
+    # sign-sum reduction.
+    stack = np.stack(
+        [np.asarray(d, dtype=np.float64) for d in deltas], axis=0,
+    )
+    K = stack.shape[0]
+
+    # Step 1 — Trim : per task, zero entries below the
+    # (1 - trim_fraction) magnitude quantile.
+    abs_stack = np.abs(stack)
+    # Flatten per-task axis so we can take a per-row quantile.
+    flat_abs = abs_stack.reshape(K, -1)
+    # Quantile threshold : keep entries >= quantile(|τ_i|, 1-k).
+    # When trim_fraction == 1.0 the threshold is the min (keep
+    # everything) ; when trim_fraction is tiny the threshold is
+    # near the max (drop all but the largest entries).
+    q = 1.0 - trim_fraction
+    thresholds = np.quantile(flat_abs, q, axis=1)  # shape (K,)
+    # Broadcast threshold over the per-task slice.
+    keep_mask_shape = (K,) + (1,) * (stack.ndim - 1)
+    thresholds_b = thresholds.reshape(keep_mask_shape)
+    keep_mask = abs_stack >= thresholds_b
+    trimmed = np.where(keep_mask, stack, 0.0)
+
+    # Step 2 — Elect sign : per-parameter sign of the signed-
+    # magnitude sum across tasks. ``np.sign`` maps {<0, 0, >0} to
+    # {-1, 0, +1}.
+    signed_sum = np.sum(trimmed, axis=0)  # drop K axis
+    elected = np.sign(signed_sum)  # shape == target_shape
+
+    # Step 3 — Disjoint merge : per parameter, mean over tasks
+    # whose sign agrees with the elected sign.
+    trimmed_signs = np.sign(trimmed)
+    agree_mask = trimmed_signs == elected[None, ...]
+    # Exclude elected == 0 entries (no consensus → merged = 0).
+    agree_mask &= elected[None, ...] != 0
+
+    contrib_count = np.sum(agree_mask, axis=0)  # shape target
+    numerator = np.sum(np.where(agree_mask, trimmed, 0.0), axis=0)
+    # Divide-by-zero guard : parameters with zero contributors
+    # stay at 0 in the merged delta.
+    merged = np.where(
+        contrib_count > 0,
+        numerator / np.maximum(contrib_count, 1),
+        0.0,
+    )
+
+    merged *= alpha
+    return merged.astype(target_dtype, copy=False)
+
+
+@dataclass
+class MicroKikiRecombineState:
+    """DR-0 accountability record for the TIES-Merge recombine op.
+
+    Mirrors :class:`MicroKikiRestructureState` so the DR-3
+    conformance harness parametrises the 4 handlers uniformly.
+    Each invocation of the :meth:`recombine_handler_factory`
+    closure bumps ``total_episodes_handled`` and — when the
+    handler actually merged a non-empty delta list — records the
+    merged-tensor shape stamp on ``last_output_shape``. ``DR-1``
+    episode-id stamps land on ``last_episode_id`` + ``episode_ids``.
+    """
+
+    total_episodes_handled: int = 0
+    total_merges_applied: int = 0
+    last_episode_id: str | None = None
+    last_operation: str = "recombine"
+    last_completed: bool = False
+    last_k_deltas: int = 0
+    last_input_shape: tuple[int, ...] | None = None
+    last_output_shape: tuple[int, ...] | None = None
+    episode_ids: list[str] = field(default_factory=list)
+
 # Optional-dependency probe : ``mlx_lm`` (Apple Silicon MLX wheel
 # + LoRA adapters) is imported lazily inside the method that
 # actually needs it (:meth:`MicroKikiSubstrate.load`). We record
@@ -293,6 +468,14 @@ class MicroKikiSubstrate:
     # consistency) without poking private attributes.
     _restructure_state: MicroKikiRestructureState = field(
         default_factory=MicroKikiRestructureState,
+        init=False,
+        repr=False,
+    )
+    # DR-0 accountability state for the TIES-Merge recombine handler
+    # (arXiv 2306.01708). Same accessor pattern as
+    # ``_restructure_state`` — read-only via :meth:`recombine_state`.
+    _recombine_state: MicroKikiRecombineState = field(
+        default_factory=MicroKikiRecombineState,
         init=False,
         repr=False,
     )
@@ -528,31 +711,92 @@ class MicroKikiSubstrate:
 
     def recombine_handler_factory(
         self,
-    ) -> Callable[[NDArray, int, int], NDArray]:
-        """C-Hobson recombine → **phase-3 stub**.
+        trim_fraction: float = 0.2,
+        alpha: float = 1.0,
+    ) -> Callable[[dict, str], NDArray]:
+        """C-Hobson recombine → **TIES-Merge (phase 2)**.
 
-        Raises ``NotImplementedError`` : real implementation
-        requires a TIES-style merge (Yadav et al.,
-        *Resolving Interference When Merging Models*, arXiv
-        2306.01708) over a pair of per-domain LoRA adapters
-        (micro-kiki ships 32 experts). Merging two LoRAs is not
-        a raw latent interpolation ; the TIES sign-trim /
-        magnitude-elect procedure must be applied to respect the
-        downstream stack orthogonality guarantees. Deferred to
-        phase 3 — unblocks once the 32-expert curriculum
-        stabilises.
+        Wires the TIES-Merging algorithm of Yadav et al. (arXiv
+        2306.01708) : given a list of task-specific delta tensors
+        carried on ``payload["deltas"]``, the handler returns the
+        merged delta via trim → elect-sign → disjoint-mean. Scale
+        coefficient ``alpha`` amplifies the final merged
+        contribution (default ``1.0``, paper default).
+
+        Handler contract
+        ----------------
+        ``payload`` is a dict carrying at least ``"deltas"`` — a
+        list of numpy delta tensors (shape-consistent across the
+        list). Pragmatically matches ``DreamEpisode`` where the
+        canonical access path is ``episode.payload["deltas"]``.
+
+        - ``"deltas"`` : ``list[ndarray]`` — per-task / per-stack
+          ``τ_i = W_ft_i - W_base``. Empty list raises (caller
+          handles the no-op leg explicitly).
+        - Optional ``"episode_id"`` : DR-0 stamp propagated into
+          :attr:`_recombine_state`.
+
+        ``op`` is accepted for signature-compat with the sibling
+        :meth:`restructure_handler_factory` ; honours ``"ties"``
+        (default), ``"ties_merge"``, ``"merge"``. Any other op
+        raises ``ValueError`` — no silent no-ops per DR-3
+        condition 1.
+
+        Returns the merged delta tensor (dtype of the first input
+        delta). The substrate's ``_recombine_state`` is bumped on
+        every call (DR-0) ; the episode-id stamp (DR-1) is
+        appended when present.
+
+        Reference : Yadav et al., arXiv 2306.01708 §3.
         """
 
         def handler(
-            latents: NDArray, seed: int = 0, n_steps: int = 10,
+            payload: dict[str, Any], op: str = "ties",
         ) -> NDArray:
-            raise NotImplementedError(
-                "recombine_handler requires TIES-style LoRA merge "
-                "(Yadav et al., arXiv 2306.01708) — deferred to "
-                "phase 3 of the micro-kiki roadmap"
+            if op not in {"ties", "ties_merge", "merge"}:
+                raise ValueError(
+                    f"micro_kiki.recombine_handler: unsupported "
+                    f"op {op!r} ; expected one of "
+                    f"{{'ties', 'ties_merge', 'merge'}}"
+                )
+            if "deltas" not in payload:
+                raise KeyError(
+                    "micro_kiki.recombine_handler: payload missing "
+                    "'deltas' entry (expected list[ndarray])"
+                )
+            deltas = list(payload["deltas"])
+            episode_id = payload.get("episode_id")
+
+            # _ties_merge guards empty / single / shape-mismatch.
+            merged = _ties_merge(
+                deltas, trim_fraction=trim_fraction, alpha=alpha,
             )
 
+            # DR-0 bookkeeping.
+            self._recombine_state.total_episodes_handled += 1
+            self._recombine_state.total_merges_applied += 1
+            self._recombine_state.last_completed = True
+            self._recombine_state.last_operation = "recombine"
+            self._recombine_state.last_k_deltas = len(deltas)
+            first_shape = tuple(np.asarray(deltas[0]).shape)
+            self._recombine_state.last_input_shape = first_shape
+            self._recombine_state.last_output_shape = tuple(merged.shape)
+            if isinstance(episode_id, str):
+                self._recombine_state.last_episode_id = episode_id
+                self._recombine_state.episode_ids.append(episode_id)
+            return merged
+
         return handler
+
+    @property
+    def recombine_state(self) -> MicroKikiRecombineState:
+        """Read-only accessor for the TIES-Merge DR-0 record.
+
+        Mirrors :meth:`restructure_state`. The returned object is
+        the live state dataclass — do not mutate ; it is refreshed
+        by each handler call.
+        """
+        return self._recombine_state
 
     # ----- γ-snapshot : adapter round-trip -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreamofkiki"
-version = "0.9.0"
+version = "0.10.0"
 description = "Substrate-agnostic formal framework for dream-based knowledge consolidation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_micro_kiki_recombine.py
+++ b/tests/unit/test_micro_kiki_recombine.py
@@ -1,0 +1,278 @@
+"""TIES-Merge recombine tests — micro-kiki substrate, cycle-3 phase 2.
+
+Covers the TIES-Merge algorithm (Yadav et al., arXiv 2306.01708)
+wired into :meth:`MicroKikiSubstrate.recombine_handler_factory`.
+The paper's three-step procedure and the dream runtime's DR-0 /
+DR-1 axioms are asserted in parallel :
+
+- *Algebra* (paper §3) : trim → elect-sign → disjoint-merge on a
+  list of per-task deltas. Single-delta fast path returns
+  ``alpha * delta``. Majority-sign consensus drives the merged
+  contribution ; parameters with no consensus remain at 0.
+- *DR-0* (accountability) : every handler call bumps the
+  ``recombine_state`` counters ; ``completed=True`` and
+  ``operation='recombine'`` are recorded.
+- *DR-1* (episodic stamp) : an ``episode_id`` carried on the
+  payload dict is propagated to ``state.last_episode_id`` and
+  appended to ``state.episode_ids``.
+
+Numpy-only ; runs on any host (no MLX / torch dep). Reference :
+``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md`` §6.2
+(DR-0, DR-1, DR-3).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kiki_oniric.substrates.micro_kiki import (
+    MicroKikiRecombineState,
+    MicroKikiSubstrate,
+    _ties_merge,
+)
+
+
+# ---------------------------------------------------------------
+# _ties_merge — pure-function algebra
+# ---------------------------------------------------------------
+
+
+def test_ties_merge_single_delta_is_alpha_scaled() -> None:
+    """Single-task fast path : returns ``alpha * delta`` verbatim.
+
+    No election / trim step when only one task contributes —
+    there is no interference to resolve.
+    """
+    delta = np.array([1.0, -2.0, 3.0, -4.0], dtype=np.float32)
+    merged = _ties_merge([delta], trim_fraction=0.2, alpha=1.0)
+    np.testing.assert_allclose(merged, delta)
+    # Alpha scaling.
+    merged_scaled = _ties_merge([delta], trim_fraction=0.2, alpha=2.5)
+    np.testing.assert_allclose(merged_scaled, 2.5 * delta, rtol=1e-6)
+    # Dtype preserved from first input.
+    assert merged.dtype == delta.dtype
+
+
+def test_ties_merge_two_opposing_deltas_sign_consensus() -> None:
+    """Two deltas disagreeing per-element : elected sign wins by
+    magnitude ; disjoint merge keeps only the majority.
+
+    With deltas ``d1 = [5, -1]`` and ``d2 = [-2, 3]`` :
+    - position 0 : signed sum = 5 + (-2) = 3 > 0 → elect ``+``;
+      only ``d1[0] = 5`` agrees → merged = 5.
+    - position 1 : signed sum = -1 + 3 = 2 > 0 → elect ``+``;
+      only ``d2[1] = 3`` agrees → merged = 3.
+
+    Use ``trim_fraction=1.0`` so no entries are trimmed (purely
+    tests the sign-election + disjoint-merge legs).
+    """
+    d1 = np.array([5.0, -1.0], dtype=np.float64)
+    d2 = np.array([-2.0, 3.0], dtype=np.float64)
+    merged = _ties_merge([d1, d2], trim_fraction=1.0, alpha=1.0)
+    np.testing.assert_allclose(merged, [5.0, 3.0])
+
+
+def test_ties_merge_sign_election_three_deltas() -> None:
+    """Three deltas with signs [+, +, -] at every position : elect
+    ``+`` ; merged = mean of the two ``+`` deltas.
+
+    Paper §3 : election is by signed-magnitude sum, and the
+    disjoint merge averages only over agreeing tasks.
+    """
+    d1 = np.array([1.0, 2.0], dtype=np.float64)
+    d2 = np.array([3.0, 4.0], dtype=np.float64)
+    d3 = np.array([-10.0, -0.5], dtype=np.float64)
+    merged = _ties_merge([d1, d2, d3], trim_fraction=1.0, alpha=1.0)
+    # Pos 0 : sum = 1+3-10 = -6 → elect ``-`` ; only d3 agrees → merged = -10.
+    # Pos 1 : sum = 2+4-0.5 = 5.5 → elect ``+`` ; d1, d2 agree → mean = 3.
+    np.testing.assert_allclose(merged, [-10.0, 3.0])
+
+
+def test_ties_merge_known_input_regression() -> None:
+    """Regression test against a hand-computed small example.
+
+    Deltas (no trim — trim_fraction=1.0) :
+        d1 = [ 2, -3,  0]
+        d2 = [ 4,  1, -2]
+        d3 = [-1,  2,  5]
+
+    Signed sum : [5, 0, 3]
+    Elected  :   [+, 0, +]
+        pos 0 : d1=+, d2=+, d3=- → agree={d1,d2} → mean(2,4)=3
+        pos 1 : elected=0 → merged=0
+        pos 2 : d1=0(no sign), d2=-, d3=+ → agree={d3} (0 has
+                sign 0, excluded since elected=+) → mean=5
+    """
+    d1 = np.array([2.0, -3.0, 0.0], dtype=np.float64)
+    d2 = np.array([4.0, 1.0, -2.0], dtype=np.float64)
+    d3 = np.array([-1.0, 2.0, 5.0], dtype=np.float64)
+    merged = _ties_merge([d1, d2, d3], trim_fraction=1.0, alpha=1.0)
+    np.testing.assert_allclose(merged, [3.0, 0.0, 5.0])
+
+
+def test_ties_merge_trim_step_halves_entries() -> None:
+    """``trim_fraction=0.5`` keeps the top 50 % magnitudes per
+    task, zeroing the rest. Verified via a prepared delta where
+    the half to keep is unambiguous.
+
+    d1 = [10, 1, 10, 1]  →  trim keeps [10, _, 10, _]
+    d2 = [10, 1, 10, 1]  →  trim keeps [10, _, 10, _]
+    Merged (alpha=1.0)  =  [10, 0, 10, 0]
+    """
+    d1 = np.array([10.0, 1.0, 10.0, 1.0], dtype=np.float64)
+    d2 = np.array([10.0, 1.0, 10.0, 1.0], dtype=np.float64)
+    merged = _ties_merge([d1, d2], trim_fraction=0.5, alpha=1.0)
+    np.testing.assert_allclose(merged, [10.0, 0.0, 10.0, 0.0])
+
+
+def test_ties_merge_shape_mismatch_raises() -> None:
+    """Shape mismatch across deltas is a caller bug."""
+    d1 = np.zeros((4,), dtype=np.float32)
+    d2 = np.zeros((5,), dtype=np.float32)
+    with pytest.raises(ValueError, match="shape"):
+        _ties_merge([d1, d2])
+
+
+def test_ties_merge_empty_list_raises() -> None:
+    """Empty delta list → explicit error (caller handles no-op)."""
+    with pytest.raises(ValueError, match="at least one"):
+        _ties_merge([])
+
+
+def test_ties_merge_invalid_trim_fraction_raises() -> None:
+    """``trim_fraction`` outside ``(0, 1]`` is rejected."""
+    d = np.ones((3,), dtype=np.float32)
+    with pytest.raises(ValueError, match="trim_fraction"):
+        _ties_merge([d, d], trim_fraction=0.0)
+    with pytest.raises(ValueError, match="trim_fraction"):
+        _ties_merge([d, d], trim_fraction=1.5)
+
+
+# ---------------------------------------------------------------
+# recombine_handler_factory — DR-0 / DR-1 contract
+# ---------------------------------------------------------------
+
+
+def test_recombine_handler_callable_and_state() -> None:
+    """Factory returns a callable ; the substrate exposes a fresh
+    ``MicroKikiRecombineState`` via :attr:`recombine_state`.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    assert callable(handler)
+    assert isinstance(substrate.recombine_state, MicroKikiRecombineState)
+    # Fresh state : zero episodes handled.
+    assert substrate.recombine_state.total_episodes_handled == 0
+    assert substrate.recombine_state.total_merges_applied == 0
+    assert substrate.recombine_state.last_completed is False
+
+
+def test_recombine_handler_consumes_episode_and_stamps_dr1() -> None:
+    """End-to-end : multi-delta payload + episode_id ⇒ merged
+    tensor + DR-0 counter bump + DR-1 episode_id stamp + shape
+    stamp preserved on state.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+
+    rng = np.random.default_rng(7)
+    shape = (4, 3)
+    deltas = [
+        rng.standard_normal(shape).astype(np.float32),
+        rng.standard_normal(shape).astype(np.float32),
+        rng.standard_normal(shape).astype(np.float32),
+    ]
+    payload = {"deltas": deltas, "episode_id": "ep-recomb-7"}
+    merged = handler(payload, "ties")
+
+    # Output contract.
+    assert merged.shape == shape
+    assert merged.dtype == np.float32
+
+    # DR-0 state.
+    state = substrate.recombine_state
+    assert state.total_episodes_handled == 1
+    assert state.total_merges_applied == 1
+    assert state.last_completed is True
+    assert state.last_operation == "recombine"
+    assert state.last_k_deltas == 3
+    assert state.last_input_shape == shape
+    assert state.last_output_shape == shape
+
+    # DR-1 stamp.
+    assert state.last_episode_id == "ep-recomb-7"
+    assert state.episode_ids == ["ep-recomb-7"]
+
+    # Multi-call accumulates episode_ids.
+    payload2 = {"deltas": deltas, "episode_id": "ep-recomb-8"}
+    handler(payload2, "ties_merge")
+    payload3 = {"deltas": deltas}  # no episode_id
+    handler(payload3, "merge")
+    assert state.total_episodes_handled == 3
+    assert state.episode_ids == ["ep-recomb-7", "ep-recomb-8"]
+    assert state.last_episode_id == "ep-recomb-8"
+
+
+def test_recombine_handler_rejects_unknown_op() -> None:
+    """DR-3 condition 1 : unknown op-names fail loud — silent
+    fallbacks would mask dispatcher bugs in the conformance
+    harness.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    d = np.ones((2, 2), dtype=np.float32)
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler({"deltas": [d, d]}, "interpolate")
+
+
+def test_recombine_handler_rejects_missing_deltas_key() -> None:
+    """Payload without ``deltas`` key → explicit KeyError."""
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    with pytest.raises(KeyError, match="deltas"):
+        handler({"other": [1, 2, 3]}, "ties")
+
+
+def test_recombine_handler_propagates_empty_deltas_error() -> None:
+    """Empty ``deltas`` list → handler surfaces the underlying
+    ``_ties_merge`` ValueError rather than silently returning
+    zeros.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+    with pytest.raises(ValueError, match="at least one"):
+        handler({"deltas": []}, "ties")
+
+
+def test_recombine_snapshot_roundtrip_with_accumulator(tmp_path) -> None:
+    """Snapshot / load_snapshot round-trip survives recombine state.
+
+    The ``.npz`` accumulator is separate from the recombine state
+    dataclass, so the round-trip only needs to preserve
+    ``_current_delta``. Run a merge, seed the accumulator with
+    the merged delta, snapshot, reload into a fresh substrate,
+    assert the accumulator matches bit-for-bit.
+    """
+    substrate = MicroKikiSubstrate()
+    handler = substrate.recombine_handler_factory()
+
+    rng = np.random.default_rng(42)
+    shape = (3, 2)
+    deltas = [
+        rng.standard_normal(shape).astype(np.float32),
+        rng.standard_normal(shape).astype(np.float32),
+    ]
+    merged = handler({"deltas": deltas, "episode_id": "ep-snap"}, "ties")
+    substrate._current_delta = {"layers.0.recombined": merged}
+
+    snap = substrate.snapshot(tmp_path / "recomb-delta")
+    assert snap.exists()
+
+    fresh = MicroKikiSubstrate()
+    fresh.load_snapshot(snap)
+    assert set(fresh._current_delta.keys()) == {"layers.0.recombined"}
+    np.testing.assert_array_equal(
+        fresh._current_delta["layers.0.recombined"], merged,
+    )
+    # The new substrate has its own fresh recombine_state.
+    assert fresh.recombine_state.total_episodes_handled == 0

--- a/tests/unit/test_micro_kiki_substrate.py
+++ b/tests/unit/test_micro_kiki_substrate.py
@@ -29,7 +29,7 @@ def test_module_manifest_matches_substrate_pattern() -> None:
     the sibling ``esnn_*`` substrates (DR-3 condition 1).
     """
     assert MICRO_KIKI_SUBSTRATE_NAME == "micro_kiki"
-    assert MICRO_KIKI_SUBSTRATE_VERSION == "C-v0.8.0+PARTIAL"
+    assert MICRO_KIKI_SUBSTRATE_VERSION == "C-v0.9.0+PARTIAL"
 
     components = micro_kiki_substrate_components()
     expected = {
@@ -137,19 +137,36 @@ def test_restructure_handler_oplora_wired() -> None:
         handler(adapter, "activate", "layers.0.q_proj_B")
 
 
-def test_recombine_raises_phase_2() -> None:
-    """TDD-5 — recombine factory returns a callable that raises
-    ``NotImplementedError`` with an explicit TIES-merge citation.
-    Paired with restructure above — both phase-2 stubs must be
-    discoverable by the DR-3 conformance matrix as *callable*
-    but *deliberately un-backed* surfaces.
+def test_recombine_handler_ties_wired() -> None:
+    """TDD-5 (phase-2) — recombine factory returns a callable
+    backed by TIES-Merge (arXiv 2306.01708, Yadav et al.). The
+    phase-1 ``NotImplementedError`` gate is retired here ; the
+    full algebra is exercised in
+    ``tests/unit/test_micro_kiki_recombine.py``.
+
+    This smoke test only asserts the factory is wired (not a
+    stub) and that the handler produces a numpy array of the
+    right shape for a trivial two-delta payload.
     """
     substrate = MicroKikiSubstrate()
     handler = substrate.recombine_handler_factory()
     assert callable(handler)
-    latents = np.array([[0.5, 0.2], [0.1, 0.8]], dtype=np.float32)
-    with pytest.raises(NotImplementedError, match="TIES"):
-        handler(latents, seed=0)
+
+    d1 = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    d2 = np.array([1.0, -2.0, 3.0, -4.0], dtype=np.float32)
+    merged = handler({"deltas": [d1, d2], "episode_id": "ep-ties-0"}, "ties")
+    assert merged.shape == d1.shape
+    assert merged.dtype == d1.dtype
+
+    state = substrate.recombine_state
+    assert state.total_episodes_handled == 1
+    assert state.last_completed is True
+    assert state.last_operation == "recombine"
+    assert state.last_episode_id == "ep-ties-0"
+
+    # Unsupported op still rejected — DR-3 visibility.
+    with pytest.raises(ValueError, match="unsupported op"):
+        handler({"deltas": [d1, d2]}, "interpolate")
 
 
 def test_stub_mode_without_mlx_lm(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "dreamofkiki"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Stacked on #11. Replaces recombine NotImplementedError with TIES-Merge (Yadav et al. arXiv 2306.01708): trim -> elect-sign -> disjoint-merge across K LoRA deltas, pure numpy. 4/4 handlers now backed. 14 new tests. DualVer C-v0.8.0+PARTIAL -> C-v0.9.0+PARTIAL (repo 0.9.0 -> 0.10.0, FC-MINOR). Merge after #11.