### PR TITLE
fix(channels): bounds-check B5 add and weight-delta

### DIFF
--- a/kiki_oniric/dream/channels/hierarchy_change.py
+++ b/kiki_oniric/dream/channels/hierarchy_change.py
@@ -58,6 +58,11 @@ def _apply_topology_op(
         rank = int(payload["rank"])  # type: ignore[arg-type]
         alpha = float(payload["alpha"])  # type: ignore[arg-type]
         seed = int(payload["seed"])  # type: ignore[arg-type]
+        if not (0 <= index <= len(model.layers)):
+            raise ValueError(
+                f"S3: add index {index} out of bounds for "
+                f"{len(model.layers)} layers"
+            )
         new_layer = LoRALinear(
             in_features=in_features,
             out_features=out_features,

--- a/kiki_oniric/dream/channels/weight_delta.py
+++ b/kiki_oniric/dream/channels/weight_delta.py
@@ -46,7 +46,7 @@ class LoRAWeightDeltaChannel:
         del fisher_bump  # B5: accepted to match Protocol, ignored
         for key, delta_arr in lora_delta.items():
             layer_idx, attr = self._parse_key(key)
-            if layer_idx >= len(self._target.layers):
+            if layer_idx < 0 or layer_idx >= len(self._target.layers):
                 raise ValueError(
                     f"S1: weight_delta key {key!r} references layer "
                     f"{layer_idx} but target has "

--- a/tests/unit/test_apply_channel_outputs.py
+++ b/tests/unit/test_apply_channel_outputs.py
@@ -82,6 +82,17 @@ def test_lora_weight_delta_channel_rejects_bad_key_format() -> None:
         channel.apply({"oops": np.zeros((2, 4), dtype=np.float32)})
 
 
+def test_lora_weight_delta_channel_rejects_negative_layer_idx() -> None:
+    from kiki_oniric.dream.channels.weight_delta import (
+        LoRAWeightDeltaChannel,
+    )
+
+    _, target = _clones(seed=0)
+    channel = LoRAWeightDeltaChannel(target)
+    with pytest.raises(ValueError, match=r"^S1:"):
+        channel.apply({"layer-1.lora_a": np.zeros((2, 4), dtype=np.float32)})
+
+
 def test_lora_weight_delta_channel_rejects_out_of_range_layer() -> None:
     from kiki_oniric.dream.channels.weight_delta import (
         LoRAWeightDeltaChannel,
@@ -164,6 +175,34 @@ def test_hierarchy_change_channel_add_seed_reproducible() -> None:
     np.testing.assert_array_equal(
         np.asarray(inserted_a.base_weight), np.asarray(reference.base_weight),
     )
+
+
+def test_hierarchy_change_channel_add_rejects_negative_index() -> None:
+    """add with a negative insert index is rejected (S3)."""
+    from kiki_oniric.dream.channels.hierarchy_change import (
+        LoRAHierarchyChangeChannel,
+    )
+
+    _, target = _clones(seed=0)
+    channel = LoRAHierarchyChangeChannel(target)
+    entry = _make_topology_diff_add(seed=42, index=-1)
+    with pytest.raises(ValueError, match=r"^S3:"):
+        channel.apply_diff([entry])
+
+
+def test_hierarchy_change_channel_add_rejects_index_too_large() -> None:
+    """add with index > len(layers) is rejected (S3)."""
+    from kiki_oniric.dream.channels.hierarchy_change import (
+        LoRAHierarchyChangeChannel,
+    )
+
+    _, target = _clones(seed=0)
+    channel = LoRAHierarchyChangeChannel(target)
+    entry = _make_topology_diff_add(
+        seed=42, index=len(target.layers) + 5,
+    )
+    with pytest.raises(ValueError, match=r"^S3:"):
+        channel.apply_diff([entry])
 
 
 def test_hierarchy_change_channel_remove_shrinks_layer() -> None:


### PR DESCRIPTION
Closes #24.

- `_apply_topology_op` add branch now rejects `index < 0` or `index > len(layers)` with an S3 error before `model.layers.insert`.
- `LoRAWeightDeltaChannel.apply` now rejects negative `layer_idx` (in addition to the existing upper-bound check) with an S1 error.
- 3 new unit tests in `tests/unit/test_apply_channel_outputs.py`:
  - `test_hierarchy_change_channel_add_rejects_negative_index`
  - `test_hierarchy_change_channel_add_rejects_index_too_large`
  - `test_lora_weight_delta_channel_rejects_negative_layer_idx`

`uv run pytest tests/unit/ --no-cov` → 724 passed / 3 skipped (was 721/3).