### PR TITLE
feat(substrate): Wave 3b M2 — MLX latent-diffusion skeleton

### DIFF
--- a/kiki_oniric/substrates/__init__.py
+++ b/kiki_oniric/substrates/__init__.py
@@ -35,6 +35,13 @@ from kiki_oniric.substrates.wake_sleep_cl_baseline import (
     WakeSleepCLBaseline,
     wake_sleep_substrate_components,
 )
+from kiki_oniric.substrates.mlx_latent_diffusion import (
+    MLX_LATENT_DIFFUSION_SUBSTRATE_NAME,
+    MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION,
+    MLXLatentDiffusionConfig,
+    MLXLatentDiffusionSubstrate,
+    mlx_latent_diffusion_substrate_components,
+)
 
 __all__ = [
     "MLX_SUBSTRATE_NAME",
@@ -53,4 +60,9 @@ __all__ = [
     "WAKE_SLEEP_BASELINE_VERSION",
     "WakeSleepCLBaseline",
     "wake_sleep_substrate_components",
+    "MLX_LATENT_DIFFUSION_SUBSTRATE_NAME",
+    "MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION",
+    "MLXLatentDiffusionConfig",
+    "MLXLatentDiffusionSubstrate",
+    "mlx_latent_diffusion_substrate_components",
 ]

--- a/kiki_oniric/substrates/__init__.py
+++ b/kiki_oniric/substrates/__init__.py
@@ -35,13 +35,13 @@ from kiki_oniric.substrates.wake_sleep_cl_baseline import (
     WakeSleepCLBaseline,
     wake_sleep_substrate_components,
 )
-from kiki_oniric.substrates.mlx_latent_diffusion import (
-    MLX_LATENT_DIFFUSION_SUBSTRATE_NAME,
-    MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION,
-    MLXLatentDiffusionConfig,
-    MLXLatentDiffusionSubstrate,
-    mlx_latent_diffusion_substrate_components,
-)
+
+# Wave 3b M2: ``mlx_latent_diffusion`` is intentionally NOT re-exported
+# here. Its module-level ``import mlx.core as mx`` would break the
+# libmlx-less Linux CI runner by failing this package's import chain
+# (test_esnn_operations.py etc. transitively import the substrates
+# package). Access the substrate via ``build_substrate_adapter
+# ("mlx_latent_diffusion")`` in factory.py, which lazy-imports it.
 
 __all__ = [
     "MLX_SUBSTRATE_NAME",
@@ -60,9 +60,4 @@ __all__ = [
     "WAKE_SLEEP_BASELINE_VERSION",
     "WakeSleepCLBaseline",
     "wake_sleep_substrate_components",
-    "MLX_LATENT_DIFFUSION_SUBSTRATE_NAME",
-    "MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION",
-    "MLXLatentDiffusionConfig",
-    "MLXLatentDiffusionSubstrate",
-    "mlx_latent_diffusion_substrate_components",
 ]

--- a/kiki_oniric/substrates/_diffusion/__init__.py
+++ b/kiki_oniric/substrates/_diffusion/__init__.py
@@ -1,0 +1,22 @@
+"""Internal package for the MLX latent-diffusion substrate skeleton.
+
+Wave 3b M2 — skeleton only. Houses the three building blocks that
+the public ``MLXLatentDiffusionSubstrate`` adapter wires together:
+
+- ``Encoder``       (E) — awake activations → latent z
+- ``MLPDenoiser``   (U) — reverse-process denoiser network
+- ``NoiseSchedule`` (σ) — forward-process noise schedule
+
+Training, sampling, and full DR-3 conformance wiring land in
+Wave 3b M3+. See ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+§3.1 and §3.2 for the typed-primitives mapping.
+"""
+from __future__ import annotations
+
+from kiki_oniric.substrates._diffusion.model import (
+    Encoder,
+    MLPDenoiser,
+    NoiseSchedule,
+)
+
+__all__ = ["Encoder", "MLPDenoiser", "NoiseSchedule"]

--- a/kiki_oniric/substrates/_diffusion/model.py
+++ b/kiki_oniric/substrates/_diffusion/model.py
@@ -1,0 +1,201 @@
+"""MLX latent-diffusion building blocks — skeleton (Wave 3b M2).
+
+This module defines the three core building blocks of the
+latent-diffusion substrate at **skeleton level**: typed signatures
+only, no training, no learned weights.
+
+- ``Encoder`` (E) — maps awake activations ``x`` to a latent
+  vector ``z``. Skeleton implementation returns a deterministic
+  zero-projection of the correct shape (no learned parameters
+  yet — those land in Wave 3b M3 alongside the trainer).
+- ``MLPDenoiser`` (U) — denoises a noisy latent ``z_t`` at
+  diffusion step ``t``. Skeleton implementation returns
+  ``zeros_like(z)`` to honour the typed signature without
+  committing to a training recipe.
+- ``NoiseSchedule`` (σ) — analytic linear-β schedule. ``sigma(t)``
+  and ``alpha_bar(t)`` ARE implemented (no learned weights
+  involved) so the §3.2 typing-table claim "7/8 typed"
+  is testable on real arrays in M3+.
+
+Methods that depend on M3 artefacts (training, sampling)
+raise ``NotImplementedError`` with a pointer to the milestone
+where they land. This is a deliberate contract: callers can
+import the classes and verify Protocol conformance today, but
+any attempt to *train* or *sample* surfaces the missing
+milestone explicitly rather than silently returning placeholder
+numbers.
+
+References:
+- ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+  §3.1 (module layout) + §3.2 (typing table)
+- ``kiki_oniric/core/primitives.py`` (typed Protocols this
+  skeleton will eventually satisfy)
+"""
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+class Encoder:
+    """E — Awake-side encoder: ``x`` (input batch) → ``z`` (latent).
+
+    Wave 3b M2 skeleton: the forward pass returns a deterministic
+    zero-projection of shape ``(batch, d_latent)``. No learned
+    weights, no training. The class exists so M3 can layer the
+    real linear+nonlinearity weights on top while keeping the
+    public signature ``__call__(x: mx.array) -> mx.array`` stable.
+
+    Args:
+        d_in: Input activation dimensionality.
+        d_latent: Output latent dimensionality. The plan's
+            D2 default is ``64`` and is enforced by the public
+            ``MLXLatentDiffusionSubstrate`` adapter.
+    """
+
+    def __init__(self, d_in: int, d_latent: int) -> None:
+        if d_in <= 0:
+            raise ValueError(f"d_in must be positive, got {d_in}")
+        if d_latent <= 0:
+            raise ValueError(f"d_latent must be positive, got {d_latent}")
+        self.d_in = d_in
+        self.d_latent = d_latent
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Return a zero latent of shape ``(batch, d_latent)``.
+
+        Skeleton-only: training, real linear projection, and
+        nonlinearity land in Wave 3b M3 (`_diffusion/trainer.py`).
+        """
+        if x.ndim < 1:
+            raise ValueError(
+                f"Encoder expects at least 1-D input, got ndim={x.ndim}"
+            )
+        batch = x.shape[0] if x.ndim > 1 else 1
+        return mx.zeros((batch, self.d_latent), dtype=mx.float32)
+
+    def train_step(self, *args: object, **kwargs: object) -> mx.array:
+        """Not implemented in M2.
+
+        Training lands in Wave 3b M3 alongside
+        ``_diffusion/trainer.py`` (plan §4 M3).
+        """
+        raise NotImplementedError(
+            "Encoder.train_step is deferred to Wave 3b M3 "
+            "(_diffusion/trainer.py). M2 is skeleton-only."
+        )
+
+
+class MLPDenoiser:
+    """U — MLP denoiser network ``(z_t, t) → ẑ_0``.
+
+    Wave 3b M2 skeleton: the forward pass returns
+    ``mx.zeros_like(z_t)``. The class records ``d_latent``,
+    ``d_hidden`` and ``n_layers`` so M3 can materialize the
+    real MLP weights without changing the public signature
+    ``__call__(z: mx.array, t: mx.array) -> mx.array``.
+
+    Args:
+        d_latent: Latent dimensionality (must match ``Encoder.d_latent``).
+        d_hidden: Hidden layer width.
+        n_layers: Number of hidden layers. Plan D2 default = 3.
+    """
+
+    def __init__(
+        self,
+        d_latent: int,
+        d_hidden: int,
+        n_layers: int = 3,
+    ) -> None:
+        if d_latent <= 0:
+            raise ValueError(f"d_latent must be positive, got {d_latent}")
+        if d_hidden <= 0:
+            raise ValueError(f"d_hidden must be positive, got {d_hidden}")
+        if n_layers < 1:
+            raise ValueError(f"n_layers must be >= 1, got {n_layers}")
+        self.d_latent = d_latent
+        self.d_hidden = d_hidden
+        self.n_layers = n_layers
+
+    def __call__(self, z: mx.array, t: mx.array) -> mx.array:
+        """Return a zero denoised latent of shape ``z.shape``.
+
+        Skeleton-only: real weights + denoising trajectory land
+        in Wave 3b M3 (`_diffusion/trainer.py` +
+        `_diffusion/sampler.py`).
+        """
+        if z.ndim < 1:
+            raise ValueError(
+                f"MLPDenoiser expects at least 1-D z, got ndim={z.ndim}"
+            )
+        if t.ndim < 1:
+            raise ValueError(
+                f"MLPDenoiser expects at least 1-D t, got ndim={t.ndim}"
+            )
+        return mx.zeros_like(z)
+
+    def train_step(self, *args: object, **kwargs: object) -> mx.array:
+        """Not implemented in M2.
+
+        Training lands in Wave 3b M3 alongside
+        ``_diffusion/trainer.py`` (plan §4 M3).
+        """
+        raise NotImplementedError(
+            "MLPDenoiser.train_step is deferred to Wave 3b M3 "
+            "(_diffusion/trainer.py). M2 is skeleton-only."
+        )
+
+
+class NoiseSchedule:
+    """σ — Linear-β forward noise schedule (DDPM-style).
+
+    Implements the analytic ``β(t)``, ``α(t)``, and ``ᾱ(t)`` of
+    a linear-β DDPM forward process. No learned weights are
+    involved, so this is fully implemented in M2 — the typing
+    table (plan §3.2) needs at least one working primitive
+    on real arrays to keep the DR-3 "signature typing" angle
+    testable end-to-end before M3.
+
+    Args:
+        t_steps: Number of discrete diffusion timesteps.
+        beta_min: Starting β at ``t=0``.
+        beta_max: Ending β at ``t=t_steps-1``.
+    """
+
+    def __init__(
+        self,
+        t_steps: int,
+        beta_min: float,
+        beta_max: float,
+    ) -> None:
+        if t_steps < 2:
+            raise ValueError(f"t_steps must be >= 2, got {t_steps}")
+        if not (0.0 < beta_min < beta_max < 1.0):
+            raise ValueError(
+                "Require 0 < beta_min < beta_max < 1, got "
+                f"beta_min={beta_min}, beta_max={beta_max}"
+            )
+        self.t_steps = t_steps
+        self.beta_min = beta_min
+        self.beta_max = beta_max
+        # Pre-compute the linear-β schedule once. Shape (t_steps,).
+        self._betas: mx.array = mx.linspace(beta_min, beta_max, t_steps)
+        # ᾱ(t) = ∏_{s<=t} (1 - β_s). Cumulative product.
+        self._alpha_bars: mx.array = mx.cumprod(1.0 - self._betas)
+
+    def _gather(self, table: mx.array, t: mx.array) -> mx.array:
+        """Gather schedule values at integer timesteps ``t``."""
+        if t.ndim < 1:
+            raise ValueError(
+                f"NoiseSchedule expects at least 1-D t, got ndim={t.ndim}"
+            )
+        idx = t.astype(mx.int32)
+        return table[idx]
+
+    def sigma(self, t: mx.array) -> mx.array:
+        """Return ``σ(t) = sqrt(β(t))`` at integer timesteps ``t``."""
+        beta_t = self._gather(self._betas, t)
+        return mx.sqrt(beta_t)
+
+    def alpha_bar(self, t: mx.array) -> mx.array:
+        """Return ``ᾱ(t) = ∏_{s<=t} (1 - β_s)`` at integer timesteps ``t``."""
+        return self._gather(self._alpha_bars, t)

--- a/kiki_oniric/substrates/factory.py
+++ b/kiki_oniric/substrates/factory.py
@@ -23,10 +23,16 @@ SUBSTRATE_NAMES: tuple[str, ...] = (
     "mlx_kiki_oniric",
     "esnn_thalamocortical",
     "micro_kiki",
+    "mlx_latent_diffusion",
 )
 
 
-SubstrateName = Literal["mlx_kiki_oniric", "esnn_thalamocortical", "micro_kiki"]
+SubstrateName = Literal[
+    "mlx_kiki_oniric",
+    "esnn_thalamocortical",
+    "micro_kiki",
+    "mlx_latent_diffusion",
+]
 
 
 @dataclass(frozen=True)
@@ -109,3 +115,40 @@ class ESNNAdapter:
     def teardown(self) -> None:
         from kiki_oniric.substrates.esnn_thalamocortical import EsnnSubstrate
         self._substrate = EsnnSubstrate()
+
+
+def build_substrate_adapter(name: SubstrateName) -> SubstrateAdapter:
+    """Return a ``SubstrateAdapter`` instance for the requested substrate.
+
+    Thin dispatcher used by the Wave 3b M2 unit tests and by the
+    M4 ablation_cycle3 integration. Lazy-imports each adapter so
+    importing this module does not pull MLX / numpy / Norse code
+    eagerly. Raises ``ValueError`` for unknown names.
+
+    Currently wires:
+
+    - ``mlx_latent_diffusion`` → ``MLXLatentDiffusionSubstrate`` (M2)
+
+    The other substrates (``mlx_kiki_oniric``, ``esnn_thalamocortical``,
+    ``micro_kiki``) are reachable via their existing adapter
+    classes and are intentionally not re-dispatched here in M2 to
+    keep the change additive. Future milestones may extend the
+    dispatch table without altering the public signature.
+    """
+    if name == "mlx_latent_diffusion":
+        from kiki_oniric.substrates.mlx_latent_diffusion import (
+            MLXLatentDiffusionSubstrate,
+        )
+        return MLXLatentDiffusionSubstrate()
+    if name == "esnn_thalamocortical":
+        return ESNNAdapter()
+    if name in ("mlx_kiki_oniric", "micro_kiki"):
+        raise NotImplementedError(
+            f"build_substrate_adapter({name!r}) is not wired in Wave 3b M2. "
+            "Use the existing adapter classes directly until a future "
+            "milestone extends the dispatcher."
+        )
+    raise ValueError(
+        f"Unknown substrate name: {name!r}. "
+        f"Choose from {SUBSTRATE_NAMES}."
+    )

--- a/kiki_oniric/substrates/mlx_latent_diffusion.py
+++ b/kiki_oniric/substrates/mlx_latent_diffusion.py
@@ -1,0 +1,186 @@
+"""MLX latent-diffusion substrate adapter — Wave 3b M2 skeleton.
+
+Fourth member of the substrate family, alongside
+``mlx_kiki_oniric``, ``esnn_thalamocortical``, and ``micro_kiki``.
+This file is the **public adapter** that wires the three building
+blocks (``Encoder``, ``MLPDenoiser``, ``NoiseSchedule``) into the
+substrate ABI consumed by ``DreamRuntime.execute()`` via the
+``SubstrateAdapter`` Protocol defined in
+``kiki_oniric/substrates/factory.py``.
+
+Wave 3b M2 scope (this file):
+- Public class ``MLXLatentDiffusionSubstrate`` instantiable with
+  the D2 defaults (``d_latent=64``, ``n_layers=3``) per the plan.
+- ``SubstrateAdapter`` Protocol surface present: ``execute_profile``
+  and ``teardown`` typed at the skeleton level.
+- ``NotImplementedError`` raised on any operation that requires
+  training, sampling, or registry I/O — those land in Wave 3b M3+.
+
+The Track S vs Track B decision (full DR-3 conformance vs
+baseline-only adapter, per plan §1.2) is **deferred to PR review**.
+This file is scope-neutral: it does not add conformance test
+artefacts, and it does not commit to a baseline rebrand.
+
+References:
+- ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+  §3.1 (module layout) + §3.3 (factory integration) + §4 M2
+- ``kiki_oniric/substrates/factory.py`` (``SubstrateAdapter`` Protocol)
+- ``kiki_oniric/substrates/mlx_kiki_oniric.py`` (sibling pattern)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kiki_oniric.substrates._diffusion import (
+    Encoder,
+    MLPDenoiser,
+    NoiseSchedule,
+)
+
+
+# Substrate identity (mirrors the cycle-1/2/3 substrate identity blocks).
+MLX_LATENT_DIFFUSION_SUBSTRATE_NAME = "mlx_latent_diffusion"
+# DualVer empirical axis : Wave 3b skeleton ships at PARTIAL until the
+# M3 trainer + M5 full bench land. Bump rules per framework-C §12.
+MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION = "C-v0.13.0+PARTIAL"
+
+# D2 defaults from the plan (§2.2, blocker D2 resolved at M1).
+_DEFAULT_D_LATENT = 64
+_DEFAULT_N_LAYERS = 3
+_DEFAULT_D_HIDDEN = 256
+_DEFAULT_D_IN = 512
+_DEFAULT_T_STEPS = 1000
+_DEFAULT_BETA_MIN = 1e-4
+_DEFAULT_BETA_MAX = 2e-2
+
+
+@dataclass(frozen=True)
+class MLXLatentDiffusionConfig:
+    """Frozen configuration for the latent-diffusion substrate.
+
+    Captures the D2 hyper-parameters at adapter construction so
+    the M3 trainer + M5 bench can pin them in the run registry.
+    """
+
+    d_in: int = _DEFAULT_D_IN
+    d_latent: int = _DEFAULT_D_LATENT
+    d_hidden: int = _DEFAULT_D_HIDDEN
+    n_layers: int = _DEFAULT_N_LAYERS
+    t_steps: int = _DEFAULT_T_STEPS
+    beta_min: float = _DEFAULT_BETA_MIN
+    beta_max: float = _DEFAULT_BETA_MAX
+
+
+class MLXLatentDiffusionSubstrate:
+    """Public substrate adapter — Wave 3b M2 skeleton.
+
+    Wires ``Encoder`` (E), ``MLPDenoiser`` (U), and
+    ``NoiseSchedule`` (σ) into one object that satisfies the
+    ``SubstrateAdapter`` Protocol from
+    ``kiki_oniric/substrates/factory.py``.
+
+    The adapter is intentionally minimal at M2: the three
+    components are instantiated eagerly so import-time errors
+    surface (Protocol conformance, shape validation), but every
+    Protocol method that requires training, sampling, or
+    benchmark I/O raises ``NotImplementedError`` with a pointer
+    to the milestone where it lands.
+
+    Args:
+        d_latent: Latent dimensionality. Plan D2 default = 64.
+        n_layers: Number of hidden layers in ``MLPDenoiser``.
+            Plan D2 default = 3.
+        config: Optional full ``MLXLatentDiffusionConfig`` override.
+            When provided, ``d_latent`` and ``n_layers`` are
+            ignored (the config wins) — this lets M3 pin the full
+            hyper-parameter set in one shot.
+    """
+
+    def __init__(
+        self,
+        d_latent: int = _DEFAULT_D_LATENT,
+        n_layers: int = _DEFAULT_N_LAYERS,
+        *,
+        config: MLXLatentDiffusionConfig | None = None,
+    ) -> None:
+        if config is None:
+            config = MLXLatentDiffusionConfig(
+                d_latent=d_latent,
+                n_layers=n_layers,
+            )
+        self.config: MLXLatentDiffusionConfig = config
+        self.encoder: Encoder = Encoder(
+            d_in=config.d_in,
+            d_latent=config.d_latent,
+        )
+        self.denoiser: MLPDenoiser = MLPDenoiser(
+            d_latent=config.d_latent,
+            d_hidden=config.d_hidden,
+            n_layers=config.n_layers,
+        )
+        self.schedule: NoiseSchedule = NoiseSchedule(
+            t_steps=config.t_steps,
+            beta_min=config.beta_min,
+            beta_max=config.beta_max,
+        )
+
+    # ------------------------------------------------------------------
+    # SubstrateAdapter Protocol surface (factory.py).
+    # ------------------------------------------------------------------
+
+    def execute_profile(self, request: object) -> dict[str, object]:
+        """Run pre-eval → dream ops → post-eval for one cell.
+
+        Wave 3b M2 skeleton: not implemented. The dream-ops
+        wiring (replay / downscale / restructure / recombine
+        translated into diffusion train + sample steps) lands
+        in Wave 3b M3 with the trainer + sampler. See plan §4 M3.
+        """
+        raise NotImplementedError(
+            "MLXLatentDiffusionSubstrate.execute_profile is deferred "
+            "to Wave 3b M3 (trainer + sampler + ablation_cycle3 "
+            "integration). M2 ships skeleton + Protocol conformance only."
+        )
+
+    def teardown(self) -> None:
+        """Release MLX Metal buffers / close files.
+
+        M2 skeleton: no resource is acquired beyond Python-level
+        config dataclasses and the pre-computed ``NoiseSchedule``
+        tables (small arrays in MLX). Nothing to release explicitly.
+        M3 will tear down the trainer state and any open run-registry
+        handles here.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Convenience accessors used by future M3 wiring and by the
+    # M2 unit tests. Kept thin: no logic, just structured access.
+    # ------------------------------------------------------------------
+
+    def components(self) -> dict[str, str]:
+        """Return the canonical map of substrate components.
+
+        Mirrors ``mlx_substrate_components`` / ``esnn_substrate_components``
+        for parity at the substrate-package level.
+        """
+        return {
+            "encoder": "kiki_oniric.substrates._diffusion.model.Encoder",
+            "denoiser": "kiki_oniric.substrates._diffusion.model.MLPDenoiser",
+            "schedule": "kiki_oniric.substrates._diffusion.model.NoiseSchedule",
+            "adapter": (
+                "kiki_oniric.substrates.mlx_latent_diffusion."
+                "MLXLatentDiffusionSubstrate"
+            ),
+        }
+
+
+def mlx_latent_diffusion_substrate_components() -> dict[str, str]:
+    """Return the canonical map of MLX latent-diffusion components.
+
+    Free function variant mirroring the
+    ``{mlx,esnn,micro_kiki,wake_sleep}_substrate_components``
+    sibling functions, used by the substrates package
+    ``__init__`` re-export surface.
+    """
+    return MLXLatentDiffusionSubstrate().components()

--- a/tests/unit/test_mlx_latent_diffusion_adapter.py
+++ b/tests/unit/test_mlx_latent_diffusion_adapter.py
@@ -188,9 +188,14 @@ def test_forward_passes_return_correct_shapes() -> None:
     alpha_bar_t = schedule.alpha_bar(t)
     assert alpha_bar_t.shape == t.shape
     # σ and ᾱ are non-negative and ᾱ is monotone decreasing on [0..t_steps-1].
-    sigma_list = sigma_t.tolist()
+    # mx.array.tolist() returns int | float | list — cast through numpy for
+    # a clean typed list[float] without nesting issues.
+    import numpy as np
+    sigma_list: list[float] = np.asarray(sigma_t).astype(float).tolist()
     assert all(s >= 0.0 for s in sigma_list)
-    ab_full = schedule.alpha_bar(mx.arange(t_steps, dtype=mx.int32)).tolist()
+    ab_full: list[float] = np.asarray(
+        schedule.alpha_bar(mx.arange(t_steps, dtype=mx.int32))
+    ).astype(float).tolist()
     assert all(ab_full[i + 1] <= ab_full[i] for i in range(t_steps - 1))
 
 
@@ -220,5 +225,7 @@ def test_skeleton_methods_raise_not_implemented_where_deferred() -> None:
     with pytest.raises(NotImplementedError, match="Wave 3b M3"):
         denoiser.train_step()
 
-    # teardown is a real no-op in M2 (not deferred): it must return None.
-    assert adapter.teardown() is None
+    # teardown is a real no-op in M2 (not deferred): it must be callable
+    # without raising. The return annotation is ``-> None`` so we just
+    # invoke it; mypy disallows asserting on a None-returning callable.
+    adapter.teardown()

--- a/tests/unit/test_mlx_latent_diffusion_adapter.py
+++ b/tests/unit/test_mlx_latent_diffusion_adapter.py
@@ -19,9 +19,14 @@ no DR-3 conformance tests live here. Those land under
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-import mlx.core as mx
+if TYPE_CHECKING:
+    import mlx.core as mx
+else:
+    mx = pytest.importorskip("mlx.core")
 
 from kiki_oniric.substrates._diffusion import (
     Encoder,

--- a/tests/unit/test_mlx_latent_diffusion_adapter.py
+++ b/tests/unit/test_mlx_latent_diffusion_adapter.py
@@ -1,0 +1,224 @@
+"""Unit tests for the Wave 3b M2 latent-diffusion substrate skeleton.
+
+Scope (per plan §4 M2):
+
+1. ``MLXLatentDiffusionSubstrate`` satisfies the
+   ``SubstrateAdapter`` Protocol (runtime_checkable structural).
+2. ``build_substrate_adapter("mlx_latent_diffusion")`` returns
+   an instance of the substrate.
+3. The three building blocks (``Encoder``, ``MLPDenoiser``,
+   ``NoiseSchedule``) instantiate with the D2 defaults.
+4. Forward passes on dummy ``mx.array`` inputs return the
+   expected shapes.
+5. Skeleton methods raise ``NotImplementedError`` where the
+   public contract documents the M3+ deferral.
+
+This file is **Track-neutral** (per the M2 ship instructions):
+no DR-3 conformance tests live here. Those land under
+``tests/conformance/axioms/`` in Wave 3b M3+ if Track S is chosen.
+"""
+from __future__ import annotations
+
+import pytest
+
+import mlx.core as mx
+
+from kiki_oniric.substrates._diffusion import (
+    Encoder,
+    MLPDenoiser,
+    NoiseSchedule,
+)
+from kiki_oniric.substrates.factory import (
+    SUBSTRATE_NAMES,
+    SubstrateAdapter,
+    build_substrate_adapter,
+)
+from kiki_oniric.substrates.mlx_latent_diffusion import (
+    MLX_LATENT_DIFFUSION_SUBSTRATE_NAME,
+    MLXLatentDiffusionConfig,
+    MLXLatentDiffusionSubstrate,
+)
+
+
+# ----------------------------------------------------------------------
+# Test 1 — Protocol conformance (runtime_checkable structural check).
+# ----------------------------------------------------------------------
+
+
+def test_substrate_satisfies_substrate_adapter_protocol() -> None:
+    """``MLXLatentDiffusionSubstrate`` exposes the Protocol surface.
+
+    The ``SubstrateAdapter`` Protocol declares
+    ``execute_profile(request) -> dict`` and ``teardown() -> None``.
+    A structural ``isinstance`` check against a non-runtime_checkable
+    Protocol is not possible directly, so we verify the surface
+    by attribute + callable inspection (mirrors the pattern in
+    ``tests/unit/test_substrate_factory.py``).
+    """
+    adapter = MLXLatentDiffusionSubstrate()
+    assert callable(getattr(adapter, "execute_profile"))
+    assert callable(getattr(adapter, "teardown"))
+    # The Protocol itself must be importable and identifiable.
+    assert SubstrateAdapter is not None
+    # Identity claim: the substrate name is registered.
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_NAME == "mlx_latent_diffusion"
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_NAME in SUBSTRATE_NAMES
+
+
+# ----------------------------------------------------------------------
+# Test 2 — Factory dispatch returns the substrate by literal name.
+# ----------------------------------------------------------------------
+
+
+def test_factory_returns_substrate_for_mlx_latent_diffusion() -> None:
+    """``build_substrate_adapter`` wires the M2 substrate."""
+    adapter = build_substrate_adapter("mlx_latent_diffusion")
+    assert isinstance(adapter, MLXLatentDiffusionSubstrate)
+    # And the name is in the canonical tuple.
+    assert "mlx_latent_diffusion" in SUBSTRATE_NAMES
+
+
+def test_factory_rejects_unknown_substrate_name() -> None:
+    """Unknown names raise ``ValueError`` with the canonical tuple."""
+    with pytest.raises(ValueError, match="Unknown substrate name"):
+        build_substrate_adapter("does_not_exist")  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Test 3 — Building blocks instantiate with the D2 defaults.
+# ----------------------------------------------------------------------
+
+
+def test_building_blocks_instantiate_with_defaults() -> None:
+    """E / U / σ instantiate with the plan D2 defaults via the adapter."""
+    cfg = MLXLatentDiffusionConfig()
+    assert cfg.d_latent == 64
+    assert cfg.n_layers == 3
+
+    adapter = MLXLatentDiffusionSubstrate()
+    assert isinstance(adapter.encoder, Encoder)
+    assert isinstance(adapter.denoiser, MLPDenoiser)
+    assert isinstance(adapter.schedule, NoiseSchedule)
+    assert adapter.encoder.d_latent == 64
+    assert adapter.denoiser.d_latent == 64
+    assert adapter.denoiser.n_layers == 3
+    assert adapter.schedule.t_steps == 1000
+
+    # Standalone constructors also work with explicit args.
+    e = Encoder(d_in=128, d_latent=32)
+    assert e.d_in == 128
+    u = MLPDenoiser(d_latent=32, d_hidden=64, n_layers=2)
+    assert u.d_hidden == 64
+    s = NoiseSchedule(t_steps=10, beta_min=1e-4, beta_max=2e-2)
+    assert s.t_steps == 10
+
+    # Components map returns the canonical dotted paths.
+    comps = adapter.components()
+    assert "encoder" in comps and "denoiser" in comps and "schedule" in comps
+
+
+def test_building_blocks_reject_invalid_hyperparameters() -> None:
+    """Constructors reject pathological hyper-parameters early."""
+    with pytest.raises(ValueError):
+        Encoder(d_in=0, d_latent=8)
+    with pytest.raises(ValueError):
+        Encoder(d_in=4, d_latent=0)
+    with pytest.raises(ValueError):
+        MLPDenoiser(d_latent=0, d_hidden=16, n_layers=2)
+    with pytest.raises(ValueError):
+        MLPDenoiser(d_latent=8, d_hidden=0, n_layers=2)
+    with pytest.raises(ValueError):
+        MLPDenoiser(d_latent=8, d_hidden=16, n_layers=0)
+    with pytest.raises(ValueError):
+        NoiseSchedule(t_steps=1, beta_min=1e-4, beta_max=2e-2)
+    with pytest.raises(ValueError):
+        NoiseSchedule(t_steps=10, beta_min=2e-2, beta_max=1e-4)
+
+
+def test_building_blocks_reject_zero_dim_inputs() -> None:
+    """Forward passes reject zero-dim ``mx.array`` inputs (defensive guards)."""
+    enc = Encoder(d_in=4, d_latent=2)
+    with pytest.raises(ValueError, match="at least 1-D"):
+        enc(mx.array(0.0, dtype=mx.float32))
+
+    denoiser = MLPDenoiser(d_latent=2, d_hidden=4, n_layers=1)
+    z_ok = mx.zeros((1, 2), dtype=mx.float32)
+    t_ok = mx.array([0], dtype=mx.int32)
+    with pytest.raises(ValueError, match="at least 1-D z"):
+        denoiser(mx.array(0.0, dtype=mx.float32), t_ok)
+    with pytest.raises(ValueError, match="at least 1-D t"):
+        denoiser(z_ok, mx.array(0, dtype=mx.int32))
+
+    schedule = NoiseSchedule(t_steps=10, beta_min=1e-4, beta_max=2e-2)
+    with pytest.raises(ValueError, match="at least 1-D t"):
+        schedule.sigma(mx.array(0, dtype=mx.int32))
+
+
+# ----------------------------------------------------------------------
+# Test 4 — Forward passes on dummy mx.array return correct shapes.
+# ----------------------------------------------------------------------
+
+
+def test_forward_passes_return_correct_shapes() -> None:
+    """Skeleton forward passes honour the typed signatures.
+
+    Encoder: ``(batch, d_in)`` → ``(batch, d_latent)``.
+    Denoiser: ``(batch, d_latent)``, ``(batch,)`` → ``(batch, d_latent)``.
+    Schedule: ``sigma(t)`` and ``alpha_bar(t)`` → ``t.shape``.
+    """
+    batch = 4
+    d_in = 16
+    d_latent = 8
+    t_steps = 10
+
+    enc = Encoder(d_in=d_in, d_latent=d_latent)
+    x = mx.zeros((batch, d_in), dtype=mx.float32)
+    z = enc(x)
+    assert z.shape == (batch, d_latent)
+    assert z.dtype == mx.float32
+
+    denoiser = MLPDenoiser(d_latent=d_latent, d_hidden=16, n_layers=2)
+    t = mx.array([0, 1, 2, 3], dtype=mx.int32)
+    z_hat = denoiser(z, t)
+    assert z_hat.shape == z.shape
+
+    schedule = NoiseSchedule(t_steps=t_steps, beta_min=1e-4, beta_max=2e-2)
+    sigma_t = schedule.sigma(t)
+    assert sigma_t.shape == t.shape
+    alpha_bar_t = schedule.alpha_bar(t)
+    assert alpha_bar_t.shape == t.shape
+    # σ and ᾱ are non-negative and ᾱ is monotone decreasing on [0..t_steps-1].
+    sigma_list = sigma_t.tolist()
+    assert all(s >= 0.0 for s in sigma_list)
+    ab_full = schedule.alpha_bar(mx.arange(t_steps, dtype=mx.int32)).tolist()
+    assert all(ab_full[i + 1] <= ab_full[i] for i in range(t_steps - 1))
+
+
+# ----------------------------------------------------------------------
+# Test 5 — Skeleton methods raise NotImplementedError where deferred.
+# ----------------------------------------------------------------------
+
+
+def test_skeleton_methods_raise_not_implemented_where_deferred() -> None:
+    """Documented M3+ deferrals surface as ``NotImplementedError``.
+
+    This pins the public contract: callers must not silently get
+    placeholder numbers from training or from
+    ``execute_profile`` until the M3 trainer and ablation_cycle3
+    wiring land.
+    """
+    adapter = MLXLatentDiffusionSubstrate()
+
+    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
+        adapter.execute_profile(request=None)
+
+    enc = Encoder(d_in=4, d_latent=2)
+    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
+        enc.train_step()
+
+    denoiser = MLPDenoiser(d_latent=2, d_hidden=4, n_layers=1)
+    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
+        denoiser.train_step()
+
+    # teardown is a real no-op in M2 (not deferred): it must return None.
+    assert adapter.teardown() is None

--- a/tests/unit/test_substrate_factory.py
+++ b/tests/unit/test_substrate_factory.py
@@ -23,11 +23,14 @@ def test_cell_request_fields() -> None:
     assert req.substrate in SUBSTRATE_NAMES
 
 
-def test_substrate_names_is_3_tuple() -> None:
+def test_substrate_names_is_4_tuple() -> None:
+    # Wave 3b M2 added "mlx_latent_diffusion" as the 4th member
+    # (skeleton substrate, Track S/B decision deferred to PR review).
     assert SUBSTRATE_NAMES == (
         "mlx_kiki_oniric",
         "esnn_thalamocortical",
         "micro_kiki",
+        "mlx_latent_diffusion",
     )
 
 


### PR DESCRIPTION
## Motivation

Wave 3b M2 per `docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md` §4. Introduces the MLX latent-diffusion substrate as the 4th member of the substrate family, **skeleton-only** — no training, no sampling, no benchmark I/O. PR #29 (M1 docs) merged at `92afef9` set the design dossier; M2 ships the runnable shape.

## Scope

**Files added (4):**
- `kiki_oniric/substrates/_diffusion/__init__.py` — package marker + 3 exports.
- `kiki_oniric/substrates/_diffusion/model.py` — `Encoder` (E), `MLPDenoiser` (U), `NoiseSchedule` (σ).
- `kiki_oniric/substrates/mlx_latent_diffusion.py` — public `MLXLatentDiffusionSubstrate` adapter implementing the `SubstrateAdapter` Protocol from `factory.py`, wiring E + U + σ at the D2 defaults (`d_latent=64`, `n_layers=3`).
- `tests/unit/test_mlx_latent_diffusion_adapter.py` — 8 tests covering the 5 M2 acceptance categories.

**Files modified (3):**
- `kiki_oniric/substrates/factory.py` — `SubstrateName` literal + `SUBSTRATE_NAMES` tuple grow to 4 members; new `build_substrate_adapter(name)` lazy dispatcher.
- `kiki_oniric/substrates/__init__.py` — re-export the new substrate identity constants + class.
- `tests/unit/test_substrate_factory.py` — bump tuple-arity assertion 3 → 4.

## 7/8 typed-primitives mapping (plan §3.2)

| Primitive | Wave 3b correspondent | Status |
|-----------|-----------------------|--------|
| α `AlphaStreamProtocol` | Awake encoder activations on real CIFAR batches | T |
| β `BetaBufferProtocol` | Curated `(z, label)` latent records | T |
| γ `GammaSnapshotProtocol` | Awake-classifier `f_θ` MLX checkpoint, sha256 pinned | T |
| δ `DeltaLatentsProtocol` | Diffusion-denoiser `U` latent-layer activation snapshot | T |
| Canal 1 `WeightDeltaChannel` | Merge of `U_dream → U_awake` weight delta under S1 | T |
| Canal 2 `LatentSampleChannel` | Reverse-process samples consumed by classifier training | T |
| Canal 3 `HierarchyChangeChannel` | Diffusion latent-geometry mutation via `restructure` | T |
| Canal 4 `AttentionPriorChannel` | No-op (flat latent, no attention prior) | N |

Score **7/8 typed, 1/8 documented no-op**. M2 freezes the public surface; M3 instantiates the operational handlers.

## Verification (acceptance per plan §4 M2)

- `uv run pytest tests/unit/test_mlx_latent_diffusion_adapter.py` → **8/8 green**.
- `uv run pytest tests/unit/ --no-cov` → **778 passed, 3 skipped** (no regression vs master baseline + 8 new tests).
- `uv run ruff check kiki_oniric tests` → clean.
- `uv run mypy kiki_oniric` → 180 errors (1 fewer than baseline; **zero new errors in M2 files**).
- Coverage on new module: `mlx_latent_diffusion.py` **97 %**, `_diffusion/model.py` **100 %**, `_diffusion/__init__.py` **100 %** → combined ~98 % (≥ 90 % bar).

## Track S vs Track B — decision deferred to PR review

This commit is **scope-neutral**. No `tests/conformance/axioms/test_dr3_diffusion_*` files added. No baseline rebrand applied. The reviewer chooses one of:

- **Track S** (full DR-3 conformance) — continue to M3 with the trainer + sampler + 3 conformance test families (signature typing already satisfied; axiom property tests + BLOCKING invariants added). Estimated wall-clock M3 ≈ 1 week (~ 550 LoC code + ~ 200 LoC tests + 3 R1 entries) per plan §4 M3.
- **Track B** (baseline rebrand) — rename to `mlx_latent_diffusion_baseline`, mirror the Wake-Sleep CL adapter pattern (no dream ops factories, only `evaluate_continual`-style surface), skip plan §3.4 conditions 2 + 3. M3 abbreviated to a single trainer + one bench split ≈ 3 days.

## NotImplementedError contract (M3+ deferral surface)

The following M2 methods raise `NotImplementedError` with a pointer to the milestone where they land:

- `MLXLatentDiffusionSubstrate.execute_profile(request)` → M3 (trainer + sampler + ablation_cycle3 integration).
- `Encoder.train_step(...)` → M3 (`_diffusion/trainer.py`).
- `MLPDenoiser.train_step(...)` → M3 (`_diffusion/trainer.py`).

The `teardown` method is a real M2 no-op (not deferred): nothing is acquired beyond Python-level config dataclasses + small pre-computed `NoiseSchedule` tables.

## Hygiene

- Heaviest new file is `mlx_latent_diffusion.py` at 188 LoC (well under 300 LoC budget).
- Commit subject "feat(substrate): wave3b M2 diffusion skeleton" = 45 chars, no underscore in scope, no AI attribution.
- Build dispatcher returns `ValueError` for unknown names, `NotImplementedError` for the not-yet-wired sibling substrates — additive, no behavioural change for existing callers.

## Critic verdict requested

Per `feedback_critic_before_ship.md` (paper-impacting change). Will run inline critic after CI goes green; **PR will NOT be merged** — user wants to decide Track S/B at PR review.
