### PR TITLE
feat(substrate): Wave 3b M3 — train + sample + R1 golden (Track S)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -679,6 +679,92 @@ see `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12).
 
 ---
 
+## [C-v0.24.0+PARTIAL] — 2026-05-21 — Wave 3b M3 diffusion train + sample + R1 (Track S)
+
+### Formal axis (FC) — MINOR (v0.23.0 → v0.24.0)
+
+- **Substrate-internal bump** `mlx_latent_diffusion` from
+  `C-v0.13.0+PARTIAL` (Wave 3b M2 skeleton) to
+  `C-v0.14.0+PARTIAL` (Wave 3b M3 — trainer + sampler + R1
+  entries shipped). EC stays `+PARTIAL` ; M6 will conditionally
+  flip to `+STABLE` per framework-C §12.3 STABLE conditions, not
+  this PR.
+- **New module** `kiki_oniric/substrates/_diffusion/sampler.py`
+  (~155 LoC) : DDPM reverse-process sampler with the R1-clean
+  per-step subkey tree (plan §2.3 D3). Documents the key
+  derivation contract `mx.random.split(root_key, num=n_steps+1)`
+  with the index-0 reservation pattern.
+- **New module** `kiki_oniric/substrates/_diffusion/trainer.py`
+  (~150 LoC) : noise-prediction SGD `Trainer.fit` and
+  `train_step`, R1-clean per-step subkey tree
+  (`split(seed_key, num=n_total+1)`). Deterministic given
+  (dataset, n_epochs, seed_key, MLX version, chip family).
+- **Model upgrade** `kiki_oniric/substrates/_diffusion/model.py` :
+  `Encoder` and `MLPDenoiser` now `nn.Module` with learnable
+  parameters and a working `train_step` (MSE reconstruction /
+  noise-prediction respectively). The M2 NotImplementedError
+  surface on `train_step` is removed ; the public `__call__`
+  shape contract is preserved.
+- **Adapter wiring**
+  `kiki_oniric/substrates/mlx_latent_diffusion.py` :
+  `execute_profile` now runs a deterministic synthetic-latent
+  smoke cycle (Trainer.fit + Sampler.sample) and returns a
+  sibling-shaped metrics dict with a `"synthetic": True` honesty
+  marker per CLAUDE.md §Working rules item 3. The
+  ablation_cycle3 wiring lands in M4.
+
+### Empirical axis (EC) — UNCHANGED (PARTIAL)
+
+- No new empirical claim. Three new R1 entries
+  (`test_r1_diffusion_train`, `test_r1_diffusion_sample`,
+  `test_r1_diffusion_full_pipeline`) captured on M5 GrosMac
+  with `status: "pending_review"` per the 2026-05-10 N2
+  rebaseline discipline. M1 Max entries placeholder with
+  `status: "pending_remote_validation"` (bootstrap on the next
+  macM1 run via `compare_or_bootstrap` unknown-status path).
+
+### Tests (Track S — DR-3 full conformance)
+
+- `tests/unit/test_diffusion_sampler_keys.py` (5 tests) —
+  R1 key-derivation contract probe.
+- `tests/conformance/axioms/test_dr3_diffusion_substrate.py`
+  (8 tests) — 3 DR-3 conditions exercised against the wired
+  substrate (7/8 typed primitives + Canal 4 documented no-op).
+- `tests/conformance/axioms/test_dr0_diffusion_de_budget.py`
+  (4 tests) — DR-0 accountability via Hypothesis on the
+  trainer loss-history length contract.
+- `tests/conformance/axioms/test_dr1_diffusion_finite.py`
+  (4 tests) — DR-1 finiteness : training + sampler terminate
+  in bounded steps, all losses finite.
+- `tests/reproducibility/test_r1_diffusion.py` (3 R1 entries).
+- `tests/unit/test_mlx_latent_diffusion_adapter.py` extended :
+  the M2 NotImplementedError-deferral test is replaced by
+  positive train + smoke-cycle tests.
+- Root `conftest.py` extended : the new diffusion conformance,
+  unit, and R1 tests are added to the libmlx-less Linux skip
+  list (collect_ignore_glob).
+
+### Packaging
+
+- `pyproject.toml` version bumped `0.21.0 → 0.22.0`.
+
+### Notes
+
+- Track S/B M2 review gate (plan §4 M2 acceptance) : **Track S
+  selected** at M2 review ; this PR ships the full DR-3
+  conformance test family (3 conditions) + the 3 R1 entries.
+- DualVer atomic bump : all updated C-v references in code
+  (substrate-internal `C-v0.13.0` → `C-v0.14.0` in
+  `mlx_latent_diffusion.py`) and the framework C-v entry above
+  (`C-v0.23.0` → `C-v0.24.0`) flip in this single PR. Dated
+  immutables (`docs/plans/2026-05-20-...`,
+  `docs/osf-amendment-wave3b.md`) are deliberately untouched
+  per `docs/CLAUDE.md` (append-only rule).
+- M4 (ablation_cycle3 integration + smoke) is the next
+  milestone ; this PR is the M3 substrate-internal closure.
+
+---
+
 ## [C-v0.23.0+PARTIAL] — 2026-05-20 — PMaxLoRAProfile wires P_max to channels (B6c)
 
 ### Formal axis (FC) — MINOR (v0.22.0 → v0.23.0)

--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,11 @@ collect_ignore_glob: list[str] = []
 if sys.platform != "darwin":
     collect_ignore_glob = [
         "tests/conformance/axioms/test_dr3_*.py",
+        "tests/conformance/axioms/test_dr0_diffusion_*.py",
+        "tests/conformance/axioms/test_dr1_diffusion_*.py",
         "tests/conformance/test_baseline_registration.py",
+        "tests/reproducibility/test_r1_diffusion.py",
+        "tests/unit/test_diffusion_*.py",
         "tests/unit/experiments/test_g4_*.py",
         "tests/unit/experiments/test_g5_*.py",
         "tests/unit/experiments/test_g6_*.py",

--- a/docs/superpowers/plans/2026-05-21-b6-lora-smoke-pilot.md
+++ b/docs/superpowers/plans/2026-05-21-b6-lora-smoke-pilot.md
@@ -1,0 +1,814 @@
+# B6 LoRA smoke pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a synthetic-workload pilot script that exercises the three LoRA profile tiers (PMinLoRAProfile, PEquLoRAProfile, PMaxLoRAProfile) end-to-end through the B5 `apply_channel_outputs` loop, verifies within-machine bit-equality + DR-4 chain inclusion at runtime, and writes a dated milestone JSON + markdown for the audit trail.
+
+**Architecture:** `scripts/pilot_b6_lora_smoke.py` builds three dream/awake `LoRAModel` clone pairs at seed 42, runs an identical core workload (2 replay + 1 downscale) plus per-tier extras (PEqu adds 1 restructure ; PMax adds 1 restructure + 1 recombine VAE), then calls each profile's `consolidate_log()`, collects wall-time / FLOPs / dispatch counts / emitted-type sets per tier, and writes the result to `docs/milestones/b6-lora-smoke-2026-05-21.{json,md}`. A unit test invokes `main(output_dir=tmp_path)` and asserts ~10 properties of the produced JSON (3 tiers present, bit-equal everywhere, dispatch counts 3/4/5, emitter strict-subset chain, DR-4 verdict PASS).
+
+**Tech Stack:** Python 3.12+, `uv`, MLX (`mlx.core`, `mlx.nn`), numpy, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-b6-lora-smoke-pilot-design.md`
+
+**No DualVer bump :** pilot is operational tooling, not a substrate change. CHANGELOG gets an Operational bullet under `## [Unreleased]` after the first run records its verdict.
+
+**Chip-family capture :** the milestone JSON records the chip family the pilot ran on (Apple M5 / M3 Ultra / M1 Max / …) via `_chip_family()` from `tests/reproducibility/_r1_helpers.py`. This is relevant given the 2026-05-20 cross-machine R1 finding (`mx.random.normal` divergence on M1 Max with raw keys) — replay and recombine *do* touch that path, so the milestone JSON will differ bit-for-bit across machines on those fields and the chip_family field documents which one is captured.
+
+---
+
+## File Structure
+
+- **Create** `scripts/pilot_b6_lora_smoke.py` — pilot entry point + helpers.
+- **Create** `tests/unit/scripts/__init__.py` — new test sub-package.
+- **Create** `tests/unit/scripts/test_pilot_b6_lora_smoke.py` — 1 test, ~10 assertions.
+- **Run** the pilot once on `main`, then **commit** the produced `docs/milestones/b6-lora-smoke-2026-05-21.json` + `.md` as the audit trail.
+- **Modify** `CHANGELOG.md` — append one Operational bullet under `[Unreleased]` documenting the first-run verdict + chip family.
+
+No code under `kiki_oniric/` or `harness/` is touched. No `pyproject.toml` change. No DualVer entry.
+
+---
+
+## Task 1: Pilot script + unit test
+
+**Files:**
+- Create: `scripts/pilot_b6_lora_smoke.py`
+- Create: `tests/unit/scripts/__init__.py`
+- Create: `tests/unit/scripts/test_pilot_b6_lora_smoke.py`
+
+- [ ] **Step 1: Create the test sub-package marker**
+
+Create `tests/unit/scripts/__init__.py` as an empty file (mirrors `tests/unit/profiles/__init__.py` pattern).
+
+```python
+```
+
+(empty file)
+
+- [ ] **Step 2: Write the failing test file**
+
+Create `tests/unit/scripts/test_pilot_b6_lora_smoke.py`:
+
+```python
+"""Unit test for the B6 LoRA smoke pilot.
+
+Invokes ``main(output_dir=tmp_path)`` and asserts the produced
+milestone JSON has the expected structure + verdicts. The pilot
+itself runs the same workload as the unit tests in aggregate
+(~1-2 s), so this is fast.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_pilot_b6_lora_smoke_writes_milestone(tmp_path: Path) -> None:
+    from scripts.pilot_b6_lora_smoke import main
+
+    results = main(output_dir=tmp_path)
+
+    json_files = list(tmp_path.glob("b6-lora-smoke-*.json"))
+    md_files = list(tmp_path.glob("b6-lora-smoke-*.md"))
+    assert len(json_files) == 1
+    assert len(md_files) == 1
+
+    # Round-trip the JSON to ensure it parses and matches the
+    # returned dict.
+    with json_files[0].open(encoding="utf-8") as fh:
+        from_disk = json.load(fh)
+    assert from_disk == results
+
+    # 3 tiers present.
+    assert set(results["tiers"].keys()) == {
+        "PMinLoRA", "PEquLoRA", "PMaxLoRA",
+    }
+
+    # Bit-equal across all tiers.
+    assert results["bit_equal_all_tiers"] is True
+    for tier in results["tiers"].values():
+        assert tier["bit_equal"] is True
+
+    # Dispatch counts match the workload (core 3 + per-tier extras).
+    assert results["tiers"]["PMinLoRA"]["dispatch_count"] == 3
+    assert results["tiers"]["PEquLoRA"]["dispatch_count"] == 4
+    assert results["tiers"]["PMaxLoRA"]["dispatch_count"] == 5
+
+    # Emitter strict-subset chain across tiers.
+    pmin_set = set(results["tiers"]["PMinLoRA"]["emitted_types"])
+    pequ_set = set(results["tiers"]["PEquLoRA"]["emitted_types"])
+    pmax_set = set(results["tiers"]["PMaxLoRA"]["emitted_types"])
+    assert pmin_set == {"WeightUpdate"}
+    assert pequ_set == {"WeightUpdate", "TopologyDiff"}
+    assert pmax_set == {
+        "WeightUpdate", "TopologyDiff", "LatentSample",
+    }
+    assert pmin_set < pequ_set < pmax_set  # strict subset chain
+
+    # DR-4 chain inclusion verdict at the milestone-JSON level.
+    assert results["dr4_chain_inclusion"]["ops_strict_subset"] is True
+    assert results["dr4_chain_inclusion"]["emitters_strict_subset"] is True
+    assert results["dr4_chain_inclusion"]["verdict"] == "PASS"
+
+    # Top-level verdict.
+    assert results["verdict"] == "PASS"
+```
+
+- [ ] **Step 3: Run to verify the test fails**
+
+Run: `uv run pytest tests/unit/scripts/test_pilot_b6_lora_smoke.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.pilot_b6_lora_smoke'`.
+
+- [ ] **Step 4: Create the pilot script**
+
+Create `scripts/pilot_b6_lora_smoke.py`:
+
+```python
+"""B6 LoRA smoke pilot — exercise the three LoRA profile tiers
+(PMinLoRAProfile, PEquLoRAProfile, PMaxLoRAProfile) end-to-end
+via the B5 ``apply_channel_outputs`` loop.
+
+Builds dream/awake ``LoRAModel`` clones at seed=42 for each tier,
+runs an identical core workload (2 replay + 1 downscale) plus
+per-tier extras (PEqu adds 1 restructure ; PMax adds 1
+restructure + 1 recombine), calls ``consolidate_log()`` to
+dispatch the channel outputs onto the awake model, then verifies
+bit-equality and DR-4 chain inclusion.
+
+Writes a dated milestone JSON + markdown to
+``docs/milestones/b6-lora-smoke-<date>.{json,md}``.
+
+Reference :
+- spec ``docs/superpowers/specs/2026-05-21-b6-lora-smoke-pilot-design.md``
+- framework-C ``docs/specs/2026-04-17-dreamofkiki-framework-C-design.md`` §3.1
+
+Usage :
+    uv run python scripts/pilot_b6_lora_smoke.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import mlx.core as mx  # noqa: E402
+import mlx.nn as nn  # noqa: E402
+
+from kiki_oniric.dream.episode import (  # noqa: E402
+    BudgetCap,
+    DreamEpisode,
+    EpisodeTrigger,
+    Operation,
+    OutputChannel,
+)
+from kiki_oniric.profiles.p_equ_lora import PEquLoRAProfile  # noqa: E402
+from kiki_oniric.profiles.p_max_lora import PMaxLoRAProfile  # noqa: E402
+from kiki_oniric.profiles.p_min_lora import PMinLoRAProfile  # noqa: E402
+
+from tests.reproducibility._r1_helpers import _chip_family  # noqa: E402
+from tests.unit.profiles._lora_helpers import (  # noqa: E402
+    assert_lora_models_equal,
+    lora_clones,
+)
+
+
+_CANONICAL_SEED = 42
+_DATE_TAG = "2026-05-21"
+_FRAMEWORK_VERSION = "C-v0.23.0+PARTIAL"
+_PACKAGE_VERSION = "0.21.0"
+_LATENT_DIM = 4
+_INPUT_DIM = 4
+
+
+class _PilotEncoder(nn.Module):  # type: ignore[misc,name-defined]
+    """Deterministic linear encoder x -> (mu, log_var).
+
+    Mirrors ``_TinyEncoder`` from
+    ``tests/unit/test_recombine_latent_sample.py`` but defined
+    locally to keep the pilot self-contained.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.mu_w = mx.ones((_LATENT_DIM, _INPUT_DIM)) * 0.1
+        self.lv_w = mx.ones((_LATENT_DIM, _INPUT_DIM)) * -0.5
+
+    def __call__(self, x):  # noqa: ANN001 — mlx.nn dynamic
+        return x @ self.mu_w.T, x @ self.lv_w.T
+
+
+class _PilotDecoder(nn.Module):  # type: ignore[misc,name-defined]
+    """Deterministic linear decoder z -> output."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.w = mx.ones((_INPUT_DIM, _LATENT_DIM)) * 0.2
+
+    def __call__(self, z):  # noqa: ANN001
+        return z @ self.w.T
+
+
+def _short_head() -> str:
+    """Return the short HEAD sha or 'unknown'."""
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+    return sha or "unknown"
+
+
+def _build_core_episodes() -> list[DreamEpisode]:
+    """2 replay episodes + 1 downscale episode, identical content
+    across all three tiers."""
+    budget = BudgetCap(
+        flops=10_000_000, wall_time_s=1.0, energy_j=1.0,
+    )
+    replay_a = DreamEpisode(
+        trigger=EpisodeTrigger.SCHEDULED,
+        input_slice={
+            "beta_records": [
+                {"x": [0.1, 0.2, 0.3, 0.4], "y": [1.0, 0.0]},
+                {"x": [0.5, 0.6, 0.7, 0.8], "y": [0.0, 1.0]},
+            ],
+        },
+        operation_set=(Operation.REPLAY,),
+        output_channels=(OutputChannel.WEIGHT_DELTA,),
+        budget=budget,
+        episode_id="pilot-replay-a",
+    )
+    replay_b = DreamEpisode(
+        trigger=EpisodeTrigger.SCHEDULED,
+        input_slice={
+            "beta_records": [
+                {"x": [0.2, 0.3, 0.4, 0.5], "y": [0.0, 1.0]},
+                {"x": [0.6, 0.7, 0.8, 0.9], "y": [1.0, 0.0]},
+            ],
+        },
+        operation_set=(Operation.REPLAY,),
+        output_channels=(OutputChannel.WEIGHT_DELTA,),
+        budget=budget,
+        episode_id="pilot-replay-b",
+    )
+    downscale = DreamEpisode(
+        trigger=EpisodeTrigger.SCHEDULED,
+        input_slice={"shrink_factor": 0.5},
+        operation_set=(Operation.DOWNSCALE,),
+        output_channels=(OutputChannel.WEIGHT_DELTA,),
+        budget=budget,
+        episode_id="pilot-downscale",
+    )
+    return [replay_a, replay_b, downscale]
+
+
+def _build_pequ_extras() -> list[DreamEpisode]:
+    """1 restructure episode (reroute swap_indices=[0, 1])."""
+    return [
+        DreamEpisode(
+            trigger=EpisodeTrigger.SCHEDULED,
+            input_slice={
+                "topo_ops": [
+                    {"op": "reroute", "swap_indices": [0, 1]},
+                ],
+            },
+            operation_set=(Operation.RESTRUCTURE,),
+            output_channels=(OutputChannel.HIERARCHY_CHG,),
+            budget=BudgetCap(
+                flops=10_000_000, wall_time_s=1.0, energy_j=1.0,
+            ),
+            episode_id="pilot-restr-reroute",
+        ),
+    ]
+
+
+def _build_pmax_extras() -> list[DreamEpisode]:
+    """1 restructure (reroute) + 1 recombine (delta_latents)."""
+    return _build_pequ_extras() + [
+        DreamEpisode(
+            trigger=EpisodeTrigger.SCHEDULED,
+            input_slice={
+                "delta_latents": [[0.1, 0.2, 0.3, 0.4]],
+            },
+            operation_set=(Operation.RECOMBINE,),
+            output_channels=(OutputChannel.LATENT_SAMPLE,),
+            budget=BudgetCap(
+                flops=10_000_000, wall_time_s=1.0, energy_j=1.0,
+            ),
+            episode_id="pilot-recombine",
+        ),
+    ]
+
+
+def _collect_total_flops(profile: Any) -> int:
+    """Sum total_compute_flops across the profile's per-op
+    states, falling back to last_compute_flops for states that
+    don't track totals (e.g. the skeleton RecombineOpState).
+
+    Returns an int — informational K1 tag, no gate.
+    """
+    state_attrs = (
+        "replay_state",
+        "downscale_state",
+        "restructure_state",
+        "recombine_state",
+    )
+    total = 0
+    for attr in state_attrs:
+        state = getattr(profile, attr, None)
+        if state is None:
+            continue
+        value = getattr(
+            state,
+            "total_compute_flops",
+            getattr(state, "last_compute_flops", 0),
+        )
+        try:
+            total += int(value)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _emitted_types(profile: Any) -> list[str]:
+    """Sorted list of distinct channel-output type names seen in
+    the profile's runtime log BEFORE consolidate_log() clears it."""
+    seen: set[str] = set()
+    for entry in profile.runtime.log:
+        for output in entry.channel_outputs:
+            if output is None:
+                continue
+            seen.add(type(output).__name__)
+    return sorted(seen)
+
+
+def _run_tier(
+    name: str,
+    profile: Any,
+    episodes: list[DreamEpisode],
+    dream: Any,
+    awake: Any,
+) -> dict[str, Any]:
+    """Run all ``episodes`` on ``profile``, capture metrics,
+    call consolidate_log(), check bit-equality."""
+    wall_start = time.monotonic()
+    for ep in episodes:
+        profile.runtime.execute(ep)
+    emitted = _emitted_types(profile)
+    total_flops = _collect_total_flops(profile)
+    dispatch_count = profile.consolidate_log()
+    wall_s = time.monotonic() - wall_start
+
+    try:
+        assert_lora_models_equal(dream, awake)
+        bit_equal = True
+    except AssertionError:
+        bit_equal = False
+
+    return {
+        "tier": name,
+        "wall_s": round(wall_s, 6),
+        "dispatch_count": dispatch_count,
+        "bit_equal": bit_equal,
+        "total_flops": total_flops,
+        "emitted_types": emitted,
+    }
+
+
+def _print_table(results: dict[str, Any]) -> None:
+    """Print a small terminal table summarising per-tier metrics."""
+    print("=" * 72)
+    print(
+        "B6 LoRA SMOKE PILOT — synthetic workload, seed="
+        f"{results['seed']}, chip={results['chip_family']}"
+    )
+    print("=" * 72)
+    header = (
+        f"{'tier':10} {'wall_s':>9} {'dispatch':>9} "
+        f"{'bit_eq':>7} {'flops':>10} {'emitted':<40}"
+    )
+    print(header)
+    print("-" * 72)
+    for tier_name, tier in results["tiers"].items():
+        emitted = ",".join(tier["emitted_types"])
+        print(
+            f"{tier_name:10} {tier['wall_s']:>9.6f} "
+            f"{tier['dispatch_count']:>9} {str(tier['bit_equal']):>7} "
+            f"{tier['total_flops']:>10} {emitted:<40}"
+        )
+    print("-" * 72)
+    dr4 = results["dr4_chain_inclusion"]
+    print(
+        f"DR-4 ops_strict_subset={dr4['ops_strict_subset']} "
+        f"emitters_strict_subset={dr4['emitters_strict_subset']} "
+        f"verdict={dr4['verdict']}"
+    )
+    print(
+        f"bit_equal_all_tiers={results['bit_equal_all_tiers']} "
+        f"verdict={results['verdict']}"
+    )
+    print("=" * 72)
+
+
+def _write_markdown(
+    md_path: Path, results: dict[str, Any],
+) -> None:
+    """Write the markdown sibling next to the JSON."""
+    lines: list[str] = []
+    lines.append(f"# {results['milestone']}")
+    lines.append("")
+    lines.append(
+        f"**Date** : {results['date']}  ")
+    lines.append(
+        f"**Framework** : {results['framework_version']}  "
+    )
+    lines.append(
+        f"**Package** : {results['package_version']}  "
+    )
+    lines.append(
+        f"**Commit** : `{results['trigger_commit']}`  "
+    )
+    lines.append(
+        f"**Chip family** : `{results['chip_family']}`  "
+    )
+    lines.append(
+        f"**Seed** : `{results['seed']}`  "
+    )
+    lines.append(
+        "**Sibling JSON** : "
+        f"`{md_path.with_suffix('.json').name}`"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "First script-level exercise of the closed awake/dream "
+        "loop across the three LoRA profile tiers, post-B6c. "
+        "Synthetic workload, within-machine R1 only. No new "
+        "empirical claim — infra-validation milestone."
+    )
+    lines.append("")
+    lines.append("## Per-tier metrics")
+    lines.append("")
+    lines.append(
+        "| tier | wall_s | dispatch | bit_equal | flops | emitted |",
+    )
+    lines.append("|---|---|---|---|---|---|")
+    for tier_name, tier in results["tiers"].items():
+        emitted = ", ".join(tier["emitted_types"])
+        lines.append(
+            f"| `{tier_name}` | {tier['wall_s']:.6f} | "
+            f"{tier['dispatch_count']} | "
+            f"{tier['bit_equal']} | {tier['total_flops']} | "
+            f"{emitted} |"
+        )
+    lines.append("")
+    lines.append("## DR-4 chain inclusion")
+    lines.append("")
+    dr4 = results["dr4_chain_inclusion"]
+    lines.append(
+        f"- `ops_strict_subset` : **{dr4['ops_strict_subset']}**"
+    )
+    lines.append(
+        f"- `emitters_strict_subset` : "
+        f"**{dr4['emitters_strict_subset']}**"
+    )
+    lines.append(f"- Verdict : **{dr4['verdict']}**")
+    lines.append("")
+    lines.append("## What this does not measure")
+    lines.append("")
+    lines.append(
+        "- Cross-machine R1 — bit-equality is within-machine "
+        "only ; for cross-machine see "
+        "`docs/milestones/r1-cross-machine-m5-vs-m1-2026-05-20.{md,json}`."
+    )
+    lines.append(
+        "- Benchmark accuracy — synthetic workload, no held-out "
+        "evaluation."
+    )
+    lines.append(
+        "- Performance SLA — `wall_s` is informational."
+    )
+    lines.append(
+        "- No empirical claim — EC stays `+PARTIAL`."
+    )
+    lines.append("")
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(output_dir: Path | None = None) -> dict[str, Any]:
+    """Run the pilot, write the milestone files, return the results dict.
+
+    When ``output_dir`` is ``None`` the JSON + markdown are
+    written to ``docs/milestones/`` on the repo. Tests pass a
+    ``tmp_path`` to capture the files in a sandbox.
+    """
+    if output_dir is None:
+        output_dir = REPO_ROOT / "docs" / "milestones"
+
+    # PMinLoRA
+    pmin_dream, pmin_awake = lora_clones(seed=_CANONICAL_SEED)
+    pmin = PMinLoRAProfile(
+        dream_model=pmin_dream, awake_model=pmin_awake,
+    )
+    pmin_result = _run_tier(
+        "PMinLoRA", pmin, _build_core_episodes(),
+        pmin_dream, pmin_awake,
+    )
+
+    # PEquLoRA
+    pequ_dream, pequ_awake = lora_clones(seed=_CANONICAL_SEED)
+    pequ = PEquLoRAProfile(
+        dream_model=pequ_dream, awake_model=pequ_awake,
+    )
+    pequ_result = _run_tier(
+        "PEquLoRA", pequ,
+        _build_core_episodes() + _build_pequ_extras(),
+        pequ_dream, pequ_awake,
+    )
+
+    # PMaxLoRA — required encoder + decoder.
+    pmax_dream, pmax_awake = lora_clones(seed=_CANONICAL_SEED)
+    pmax = PMaxLoRAProfile(
+        dream_model=pmax_dream, awake_model=pmax_awake,
+        encoder=_PilotEncoder(), decoder=_PilotDecoder(),
+        seed=_CANONICAL_SEED,
+    )
+    pmax_result = _run_tier(
+        "PMaxLoRA", pmax,
+        _build_core_episodes() + _build_pmax_extras(),
+        pmax_dream, pmax_awake,
+    )
+
+    tiers = {
+        "PMinLoRA": pmin_result,
+        "PEquLoRA": pequ_result,
+        "PMaxLoRA": pmax_result,
+    }
+
+    # DR-4 chain inclusion checks.
+    pmin_ops = set(pmin.runtime._handlers.keys())
+    pequ_ops = set(pequ.runtime._handlers.keys())
+    pmax_ops = set(pmax.runtime._handlers.keys())
+    ops_strict_subset = (
+        pmin_ops < pequ_ops < pmax_ops
+    )
+
+    pmin_em = set(pmin_result["emitted_types"])
+    pequ_em = set(pequ_result["emitted_types"])
+    pmax_em = set(pmax_result["emitted_types"])
+    emitters_strict_subset = pmin_em < pequ_em < pmax_em
+
+    dr4_pass = ops_strict_subset and emitters_strict_subset
+    bit_equal_all = all(
+        t["bit_equal"] for t in tiers.values()
+    )
+    overall_pass = dr4_pass and bit_equal_all
+
+    results: dict[str, Any] = {
+        "milestone": f"b6-lora-smoke-{_DATE_TAG}",
+        "date": _DATE_TAG,
+        "framework_version": _FRAMEWORK_VERSION,
+        "package_version": _PACKAGE_VERSION,
+        "trigger_commit": _short_head(),
+        "chip_family": _chip_family(),
+        "seed": _CANONICAL_SEED,
+        "tiers": tiers,
+        "dr4_chain_inclusion": {
+            "ops_strict_subset": ops_strict_subset,
+            "emitters_strict_subset": emitters_strict_subset,
+            "verdict": "PASS" if dr4_pass else "FAIL",
+        },
+        "bit_equal_all_tiers": bit_equal_all,
+        "verdict": "PASS" if overall_pass else "FAIL",
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / f"b6-lora-smoke-{_DATE_TAG}.json"
+    md_path = output_dir / f"b6-lora-smoke-{_DATE_TAG}.md"
+    with json_path.open("w", encoding="utf-8") as fh:
+        json.dump(results, fh, indent=2, sort_keys=True)
+    _write_markdown(md_path, results)
+
+    _print_table(results)
+    print(f"\nMilestone written to {json_path}")
+    print(f"Milestone written to {md_path}")
+    return results
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 5: Run to verify the test passes**
+
+Run: `uv run pytest tests/unit/scripts/test_pilot_b6_lora_smoke.py -v`
+Expected: PASS — 1 test.
+
+- [ ] **Step 6: Full sanity (suite + mypy + ruff)**
+
+Run: `uv run pytest -q` — full suite passes (the new pilot test adds 1 ; expect 866 passed or however many are on the current branch tip).
+Run: `uv run mypy harness tests` — `Success`.
+Run: `uv run ruff check scripts/pilot_b6_lora_smoke.py tests/unit/scripts/` — clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/pilot_b6_lora_smoke.py tests/unit/scripts/__init__.py tests/unit/scripts/test_pilot_b6_lora_smoke.py
+git commit -m "$(cat <<'EOF'
+feat(pilot): B6 LoRA smoke pilot + milestone writer
+
+First script-level exercise of the closed awake/dream loop
+across the three LoRA profile tiers (PMinLoRA / PEquLoRA /
+PMaxLoRA). Synthetic workload at seed=42 — identical core (2
+replay + 1 downscale) plus per-tier extras (PEqu adds 1
+restructure ; PMax adds 1 restructure + 1 recombine). Calls
+consolidate_log() per tier, captures wall_s + total_flops +
+dispatch_count + emitted_types + within-machine bit_equal.
+
+Verifies DR-4 chain inclusion at runtime (ops strict subset +
+emitter strict subset across PMin/PEqu/PMax). Writes a dated
+milestone JSON + markdown to docs/milestones/.
+
+No DualVer bump — pilot is operational tooling, not a
+substrate change. Records the chip family via the R1
+_chip_family helper so a future cross-machine run produces a
+distinct artifact (per the 2026-05-20 cross-machine probe).
+
+Test invokes main(output_dir=tmp_path) with ~10 assertions on
+the JSON structure and per-tier verdicts.
+EOF
+)"
+```
+
+---
+
+## Task 2: Run the pilot on `main` and commit the milestone
+
+**Files:**
+- Create: `docs/milestones/b6-lora-smoke-2026-05-21.json`
+- Create: `docs/milestones/b6-lora-smoke-2026-05-21.md`
+
+- [ ] **Step 1: Run the pilot from the repo root**
+
+Run: `uv run python scripts/pilot_b6_lora_smoke.py`
+Expected: terminal table prints, `docs/milestones/b6-lora-smoke-2026-05-21.json` and `b6-lora-smoke-2026-05-21.md` are created.
+
+- [ ] **Step 2: Inspect the JSON for correctness**
+
+Run: `cat docs/milestones/b6-lora-smoke-2026-05-21.json | jq '.verdict, .bit_equal_all_tiers, .tiers | keys'`
+Expected: `"PASS"`, `true`, `["PEquLoRA", "PMaxLoRA", "PMinLoRA"]`.
+
+If the verdict is `"FAIL"`, **stop and investigate** — do not commit a failing milestone. The most likely cause is the M1 Max `mx.random.normal` divergence (see `docs/proofs/r1-cross-machine.md`) affecting `bit_equal` on a tier that touches the divergent kernel ; if so, document in the markdown sibling and adjust the spec rather than masking the result.
+
+- [ ] **Step 3: Commit the milestone**
+
+```bash
+git add docs/milestones/b6-lora-smoke-2026-05-21.json docs/milestones/b6-lora-smoke-2026-05-21.md
+git commit -m "$(cat <<'EOF'
+milestone(pilot): B6 LoRA smoke pilot first-run audit
+
+First run of scripts/pilot_b6_lora_smoke.py on main. Captures
+the chip-family + commit + per-tier metrics for the audit
+trail. Milestone files are dated immutable per
+docs/CLAUDE.md milestones convention.
+EOF
+)"
+```
+
+---
+
+## Task 3: CHANGELOG Operational bullet
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an Operational bullet under `## [Unreleased]`**
+
+Open `CHANGELOG.md`. Locate the `## [Unreleased]` section. Append the new bullet under any existing `### Operational` sub-block (or create one if absent — match the formatting of the prior Operational entries on 2026-05-04 and 2026-05-12). The bullet text :
+
+```markdown
+### Operational (B6 LoRA smoke pilot first-run, 2026-05-21)
+
+- First run of `scripts/pilot_b6_lora_smoke.py` on `main` (post-B6c).
+  Synthetic workload at seed=42 across the three LoRA profile
+  tiers exercising the closed awake↔dream loop via
+  `apply_channel_outputs`. Verdict captured in
+  `docs/milestones/b6-lora-smoke-2026-05-21.{json,md}` ; chip
+  family + commit recorded for the audit trail. Within-machine
+  R1 bit-equality verified ; DR-4 chain inclusion (ops +
+  emitters strict-subset across PMin / PEqu / PMax) verified
+  at runtime. No FC / EC bump — pilot is infra-validation, no
+  empirical claim.
+```
+
+If the file structure of `## [Unreleased]` doesn't have prior `### Operational` headers, add this block immediately under `## [Unreleased]` (search the file's top for `## [Unreleased]` and place the new sub-block on the next non-empty line).
+
+- [ ] **Step 2: Verify**
+
+Run: `git diff CHANGELOG.md` — confirm the bullet appears in the right place.
+Run: `uv run pytest -q` — full suite still passes (CHANGELOG change, no code touched).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: log B6 LoRA smoke pilot first-run operational
+
+Adds an Operational bullet under [Unreleased] in CHANGELOG.md
+documenting the first run of scripts/pilot_b6_lora_smoke.py
+on main. References the dated milestone JSON+md as the audit
+trail.
+
+No FC / EC bump — pilot is infra-validation, no empirical
+claim and no substrate change.
+EOF
+)"
+```
+
+---
+
+## Task 4: Final verification + push
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `uv run pytest -q`
+Expected: all pass, 0 failures, coverage gate met.
+
+- [ ] **Step 2: Type check**
+
+Run: `uv run mypy harness tests`
+Expected: `Success: no issues found`.
+
+- [ ] **Step 3: Lint**
+
+Run: `uv run ruff check .`
+Expected: clean.
+
+- [ ] **Step 4: Confirm working tree is clean**
+
+Run: `git status --short`
+Expected: empty (the per-family golden hashes file may show modified — restore it).
+
+- [ ] **Step 5: Push**
+
+```bash
+git push origin main
+```
+
+- [ ] **Step 6: Update issue #15 (optional)**
+
+Comment on issue #15 (closed but still receives comments) if it adds value : "B6 LoRA smoke pilot shipped — `scripts/pilot_b6_lora_smoke.py` exercises the three LoRA profile tiers end-to-end with within-machine bit-equality + runtime DR-4 chain-inclusion verification. Audit trail in `docs/milestones/b6-lora-smoke-2026-05-21.{json,md}`. No DualVer bump."
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - `scripts/pilot_b6_lora_smoke.py` with `_PilotEncoder` / `_PilotDecoder` (Task 1 Step 4) ✓
+  - `_build_core_episodes` (2 replay + 1 downscale identical across tiers) (Task 1 Step 4) ✓
+  - `_build_pequ_extras` (1 restructure reroute) (Task 1 Step 4) ✓
+  - `_build_pmax_extras` (restructure + recombine) (Task 1 Step 4) ✓
+  - `_collect_total_flops(profile)` with `getattr` fallback (Task 1 Step 4) ✓
+  - `_run_tier(name, profile, episodes, dream, awake)` collecting `wall_s` / `dispatch_count` / `bit_equal` / `total_flops` / `emitted_types` (Task 1 Step 4) ✓
+  - `main(output_dir: Path | None = None)` builds 3 profiles + runs + DR-4 chain inclusion + writes JSON+md + prints table + returns dict (Task 1 Step 4) ✓
+  - Uses `lora_clones` + `assert_lora_models_equal` from `_lora_helpers` (Task 1 Step 4 imports) ✓
+  - Imports `_chip_family` from `tests/reproducibility/_r1_helpers` (Task 1 Step 4 imports) ✓
+  - `tests/unit/scripts/__init__.py` + `tests/unit/scripts/test_pilot_b6_lora_smoke.py` with 1 test, ~10 assertions (Task 1 Steps 1-2) ✓
+  - Pilot run on `main` + commit JSON + md as audit trail (Task 2) ✓
+  - CHANGELOG `[Unreleased]` Operational bullet (Task 3) ✓
+  - No DualVer / version bump (Task 4 verifies via clean `git status`) ✓
+  - Final verification + push (Task 4) ✓
+- **Placeholder scan:** no TBD/TODO; every code step has complete code.
+- **Type consistency:**
+  - `main(output_dir: Path | None = None) -> dict[str, Any]` — test invokes with `tmp_path` and asserts on the returned dict + JSON on disk.
+  - `_PilotEncoder`, `_PilotDecoder` — same constructor / forward shape as `_TinyEncoder` / `_TinyDecoder` in B4.
+  - `lora_clones(seed)` returns `tuple[LoRAModel, LoRAModel]` — same as B6c.
+  - `assert_lora_models_equal(a, b)` — same as B6c.
+  - `_chip_family()` returns `str` — slugified per `_r1_helpers.py`.
+  - `PMinLoRAProfile(dream_model=, awake_model=)`, `PEquLoRAProfile(dream_model=, awake_model=)`, `PMaxLoRAProfile(dream_model=, awake_model=, encoder=, decoder=, seed=)` — all match the B6a/b/c profile kwargs.
+  - `profile.consolidate_log() -> int` — same name across all three profiles.
+  - `profile.runtime._handlers.keys()` — same access pattern used by B6c test 17.
+  - JSON keys (`tiers`, `dr4_chain_inclusion.{ops_strict_subset, emitters_strict_subset, verdict}`, `bit_equal_all_tiers`, `verdict`) — same names in the implementation and the test assertions.
+- **Inter-task ordering:** Task 1 (script + test) lands first ; Task 2 (run + commit milestone) depends on Task 1 ; Task 3 (CHANGELOG bullet) depends on Task 2 (it references the milestone JSON) ; Task 4 (verif + push) depends on all prior. Order 1→2→3→4 is the dependency order.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-21-b6-lora-smoke-pilot.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, inline review by me between tasks (matches the B6a / B6b / B6c pattern).
+
+**2. Inline Execution** — execute tasks in this session.

--- a/docs/superpowers/specs/2026-05-21-b6-lora-smoke-pilot-design.md
+++ b/docs/superpowers/specs/2026-05-21-b6-lora-smoke-pilot-design.md
@@ -1,0 +1,339 @@
+# B6 LoRA smoke pilot — design
+
+**Date** : 2026-05-21
+**Status** : design approved, pending spec review
+**Tracking** : informal continuation of issue #15 (B6 closed) ;
+no new issue.
+**Scope** : a synthetic-workload pilot script that exercises the
+three LoRA profile variants end-to-end via the B5 channel apply
+loop, with a milestone JSON + markdown sibling and a unit test.
+
+---
+
+## Context
+
+Approach B closed at `C-v0.23.0+PARTIAL` with B6c
+(`PMaxLoRAProfile`). All three LoRA profile tiers are wired and
+unit-tested in isolation. No script exists that *uses* them
+together — pilot_g2.py and pilot_cycle3_sanity.py predate B0 and
+use cycle-3 skeleton profiles.
+
+This pilot is the first script-level exercise of the closed
+awake↔dream loop across the full DR-4 chain. It validates the
+infrastructure (no new empirical claim), produces a dated
+milestone JSON for the audit trail, and gets covered by a unit
+test so future regressions are caught in CI.
+
+## Problem
+
+No script integrates PMinLoRA / PEquLoRA / PMaxLoRA in one run.
+The unit tests (`test_p_*_lora.py`) verify each profile in
+isolation ; the DR-4 chain test (B6c test 17) compares the three
+*statically* (op-key + emitter set inclusion). Nothing actually
+runs all three end-to-end with the same seed, the same
+synthetic workload, and compares wall-time / FLOPs / dispatch
+counts.
+
+The pilot fills that gap.
+
+## Approaches considered
+
+**Formal level.** Three options:
+
+1. **Hybride smoke + milestone JSON+md** — script in `scripts/`,
+   dated immutable milestone in `docs/milestones/`, no G-gate
+   pre-reg, no go/no-go criterion that gates a release.
+   Bit-equality and DR-4 chain inclusion are *verifications*
+   embedded in the script, not external gates. **Chosen.**
+2. G-gate G7 formal milestone — would require pre-registration
+   under `docs/osf-prereg-g7-*.md` and a hypothesis with
+   reject/accept criteria. Overkill for an infra-validation
+   exercise that makes no new empirical claim. Rejected.
+3. Pure smoke (no milestone) — same as B6a/B6b/B6c unit tests
+   but as a script. Loses the dated audit trail. Rejected.
+
+**Workload structure.** Three options:
+
+1. **Identical core + per-tier extras**. All three profiles run
+   2 replay + 1 downscale at the same seed (identical
+   `beta_records`, identical `shrink_factor`). PEqu/PMax add
+   1 restructure (reroute swap). PMax adds 1 recombine
+   (delta_latents). Total : PMin=3 episodes, PEqu=4, PMax=5.
+   Allows direct FLOP / wall-time comparison on the shared core.
+   **Chosen.**
+2. Per-tier specific — each profile gets a workload that
+   exercises its full op set. More representative but not
+   directly comparable. Rejected.
+3. Single shared episode replayed N times — too minimalist.
+   Rejected.
+
+**VAE encoder/decoder injection for PMaxLoRA.** Three options:
+
+1. **Local `_PilotEncoder` / `_PilotDecoder`** in the pilot
+   script. Deterministic linear layers with fixed weights
+   (same pattern as `_TinyEncoder`/`_TinyDecoder` in
+   `tests/unit/test_recombine_latent_sample.py`). Self-
+   contained. **Chosen.**
+2. Import from `tests/unit/test_recombine_latent_sample.py` —
+   couples `scripts/` to `tests/`. Rejected.
+3. Extract to `kiki_oniric/substrates/micro_kiki/tiny_vae.py` —
+   would promote test fixtures to production. Scope creep.
+   Rejected.
+
+**Test coverage of the pilot.** Three options:
+
+1. **Dedicated `tests/unit/scripts/test_pilot_b6_lora_smoke.py`**
+   that imports `main(output_dir=tmp_path)` and asserts on
+   the produced JSON. **Chosen.**
+2. No test — pilot is self-validating via internal asserts.
+   Matches `pilot_g2.py` precedent but loses CI regression
+   coverage. Rejected.
+3. Light sanity-only test (JSON parseable, no semantic
+   checks). Rejected — semantic checks are cheap and
+   valuable.
+
+## Design
+
+### New script `scripts/pilot_b6_lora_smoke.py`
+
+```python
+"""B6 LoRA smoke pilot — exercise the three LoRA profile variants
+end-to-end via the B5 apply_channel_outputs loop.
+
+Builds dream/awake LoRAModel clones at seed=42 for each of the
+three profile tiers (PMinLoRA / PEquLoRA / PMaxLoRA), runs an
+identical core workload (2 replay + 1 downscale) plus per-tier
+extras (PEqu/PMax add 1 restructure ; PMax adds 1 recombine),
+calls consolidate_log() to dispatch the channel outputs onto the
+awake model, then verifies bit-equality (within-machine R1) and
+DR-4 chain inclusion (ops + emitter strict subset).
+
+Writes a dated milestone JSON + markdown to docs/milestones/.
+
+Usage:
+    uv run python scripts/pilot_b6_lora_smoke.py
+"""
+```
+
+Top-level constants : `_CANONICAL_SEED = 42`, `_DATE_TAG =
+"2026-05-21"`, paths derived from `Path(__file__).resolve().
+parents[1]` like in `pilot_g2.py`.
+
+**`_PilotEncoder(nn.Module)`** : MLX `nn.Module` with two
+deterministic linear weights for `mu` and `log_var`. Mirrors
+`_TinyEncoder` from B4 tests but defined locally.
+
+**`_PilotDecoder(nn.Module)`** : single deterministic linear
+weight for the reconstruction.
+
+**`_build_core_episodes() -> list[DreamEpisode]`** : returns 3
+episodes (2 replay with fixed `beta_records`, 1 downscale with
+`shrink_factor=0.5`). Same across all 3 tiers.
+
+**`_build_pequ_extras() -> list[DreamEpisode]`** : 1 restructure
+with `topo_ops=[{"op": "reroute", "swap_indices": [0, 1]}]`.
+
+**`_build_pmax_extras() -> list[DreamEpisode]`** : 1
+restructure (same as PEqu) + 1 recombine with `delta_latents=
+[[0.1, 0.2, 0.3, 0.4]]`.
+
+**`_collect_total_flops(profile) -> int`** : sum
+`state.total_compute_flops` over the profile's 3-4 state fields,
+falling back to `getattr(state, 'total_compute_flops',
+state.last_compute_flops)` for states that don't track totals.
+
+**`_run_tier(name, profile, episodes) -> dict`** :
+```python
+{
+    "tier": name,
+    "wall_s": float,
+    "dispatch_count": int,            # consolidate_log() return
+    "bit_equal": bool,
+    "total_flops": int,
+    "emitted_types": list[str],       # sorted list of channel-output type names
+                                      # observed in profile.runtime.log BEFORE
+                                      # consolidate_log() clears it
+}
+```
+
+**`main(output_dir: Path | None = None) -> dict`** :
+- Build PMinLoRA + PEquLoRA + PMaxLoRA at seed=42 each (own
+  dream/awake `lora_clones(42)`).
+- Run their workloads, collect per-tier dicts.
+- Compute DR-4 chain inclusion verdict (`ops_strict_subset`,
+  `emitters_strict_subset`).
+- Compute global verdict (`bit_equal_all_tiers` AND
+  `dr4_chain_inclusion.verdict == "PASS"`).
+- Print a terminal table.
+- Write JSON to `output_dir / "b6-lora-smoke-<date>.json"` and
+  markdown sibling.
+- `output_dir` defaults to `REPO_ROOT / "docs" / "milestones"`.
+- Returns the results dict (also written to disk).
+
+### Milestone JSON format
+
+```json
+{
+  "milestone": "b6-lora-smoke-2026-05-21",
+  "date": "2026-05-21",
+  "framework_version": "C-v0.23.0+PARTIAL",
+  "package_version": "0.21.0",
+  "trigger_commit": "<short HEAD>",
+  "chip_family": "<sysctl machdep.cpu.brand_string slugified>",
+  "seed": 42,
+  "tiers": {
+    "PMinLoRA": {
+      "wall_s": 0.012,
+      "dispatch_count": 3,
+      "bit_equal": true,
+      "total_flops": 4096,
+      "emitted_types": ["WeightUpdate"]
+    },
+    "PEquLoRA": {
+      "wall_s": 0.018,
+      "dispatch_count": 4,
+      "bit_equal": true,
+      "total_flops": 4128,
+      "emitted_types": ["TopologyDiff", "WeightUpdate"]
+    },
+    "PMaxLoRA": {
+      "wall_s": 0.041,
+      "dispatch_count": 5,
+      "bit_equal": true,
+      "total_flops": 5120,
+      "emitted_types": ["LatentSample", "TopologyDiff", "WeightUpdate"]
+    }
+  },
+  "dr4_chain_inclusion": {
+    "ops_strict_subset": true,
+    "emitters_strict_subset": true,
+    "verdict": "PASS"
+  },
+  "bit_equal_all_tiers": true,
+  "verdict": "PASS"
+}
+```
+
+`chip_family` reuses `_chip_family()` from
+`tests/reproducibility/_r1_helpers.py` so the milestone
+captures the hardware on which it was run (relevant given the
+2026-05-20 cross-machine R1 finding).
+
+### Markdown sibling
+
+`docs/milestones/b6-lora-smoke-2026-05-21.md` is a short prose
+summary with :
+
+- Header (date, status, sibling JSON pointer, framework version).
+- The same per-tier table rendered in markdown.
+- DR-4 chain inclusion paragraph.
+- Reference to the R1 cross-machine milestone for chip-family
+  context.
+- "What this does not measure" paragraph (no cross-machine, no
+  EC claim, no benchmark accuracy).
+
+### Test — `tests/unit/scripts/test_pilot_b6_lora_smoke.py`
+
+A new test directory `tests/unit/scripts/` with `__init__.py`.
+
+```python
+def test_pilot_b6_lora_smoke_writes_milestone(tmp_path):
+    from scripts.pilot_b6_lora_smoke import main
+    results = main(output_dir=tmp_path)
+    # JSON file exists with expected name
+    json_files = list(tmp_path.glob("b6-lora-smoke-*.json"))
+    assert len(json_files) == 1
+    # Markdown sibling exists
+    md_files = list(tmp_path.glob("b6-lora-smoke-*.md"))
+    assert len(md_files) == 1
+    # 3 tiers present
+    assert set(results["tiers"].keys()) == {"PMinLoRA", "PEquLoRA", "PMaxLoRA"}
+    # Bit-equal across all tiers
+    assert results["bit_equal_all_tiers"] is True
+    for tier in results["tiers"].values():
+        assert tier["bit_equal"] is True
+    # Dispatch counts match the workload
+    assert results["tiers"]["PMinLoRA"]["dispatch_count"] == 3
+    assert results["tiers"]["PEquLoRA"]["dispatch_count"] == 4
+    assert results["tiers"]["PMaxLoRA"]["dispatch_count"] == 5
+    # Emitter strict-subset chain across tiers
+    pmin_set = set(results["tiers"]["PMinLoRA"]["emitted_types"])
+    pequ_set = set(results["tiers"]["PEquLoRA"]["emitted_types"])
+    pmax_set = set(results["tiers"]["PMaxLoRA"]["emitted_types"])
+    assert pmin_set <= pequ_set <= pmax_set
+    assert pmin_set == {"WeightUpdate"}
+    assert pequ_set == {"WeightUpdate", "TopologyDiff"}
+    assert pmax_set == {"WeightUpdate", "TopologyDiff", "LatentSample"}
+    # DR-4 chain inclusion verdict
+    assert results["dr4_chain_inclusion"]["verdict"] == "PASS"
+    assert results["verdict"] == "PASS"
+```
+
+One test, ~10 assertions. Fast (the pilot runs the same
+workload as the unit tests in aggregate, ~1-2 s).
+
+### Invariants pinned by the pilot
+
+- **R1 within-machine** — bit-equality per tier (3 assertions).
+- **DR-4 chain inclusion** — ops + emitter strict subset
+  verified at run-time (2 boolean fields in the JSON +
+  asserted in the test).
+- **K1** — `total_flops` populated per tier (informational ;
+  no gate).
+
+## Scope boundary
+
+**Pilot does** :
+- New `scripts/pilot_b6_lora_smoke.py`.
+- New `tests/unit/scripts/test_pilot_b6_lora_smoke.py` +
+  `tests/unit/scripts/__init__.py`.
+- Two new files in `docs/milestones/` after first run
+  (committed as the audit trail).
+- No code in `kiki_oniric/` or `harness/` touched.
+- No CHANGELOG / DualVer bump — pilots aren't substrate
+  changes. An "Operational" CHANGELOG entry is added under the
+  `## [Unreleased]` section for the milestone-run record.
+
+**Pilot does not** :
+- Real benchmark data (synthetic only).
+- Cross-machine comparison (within-machine R1 only).
+- Performance SLA (wall-time is informational).
+- New empirical claim (no EC bump).
+- G-gate pre-registration.
+- Modify the 3 LoRA profiles or any B-series channel.
+
+## Convention compliance
+
+- Script structure follows `pilot_g2.py` (REPO_ROOT shim,
+  `if __name__ == "__main__": main()`).
+- Milestone files follow `docs/milestones/` conventions
+  (dated immutable, md + json sibling — cf. `g2-pilot-results
+  .{md,json}` + the 2026-05-20 R1 cross-machine pair).
+- Test file lives under `tests/unit/scripts/` (new
+  sub-directory) with its own `__init__.py`. Pattern mirrors
+  `tests/unit/profiles/`.
+
+## DualVer
+
+No FC bump, no EC bump. Pilot is operational tooling, not a
+substrate change. CHANGELOG gets an "Operational" entry under
+`## [Unreleased]` documenting the milestone run (verdict + chip
+family) ; no version field changes.
+
+## Acceptance criteria
+
+1. `scripts/pilot_b6_lora_smoke.py` exists, runs to completion
+   with `uv run python scripts/pilot_b6_lora_smoke.py`, and
+   exits 0.
+2. The script writes `docs/milestones/b6-lora-smoke-<date>.json`
+   and the markdown sibling on completion.
+3. Both files commit-clean on first run for the recorder's
+   machine (additional chip families re-run later append
+   sections to the markdown but the JSON stays per-run).
+4. `tests/unit/scripts/test_pilot_b6_lora_smoke.py` passes with
+   ~10 assertions ; full pytest suite green ; mypy + ruff
+   clean.
+5. `[Unreleased]` block in `CHANGELOG.md` gets an Operational
+   bullet noting the first-run verdict + chip family.
+6. No CHANGELOG version-bump entry, no `pyproject.toml`
+   change.

--- a/kiki_oniric/substrates/_diffusion/__init__.py
+++ b/kiki_oniric/substrates/_diffusion/__init__.py
@@ -1,15 +1,19 @@
-"""Internal package for the MLX latent-diffusion substrate skeleton.
+"""Internal package for the MLX latent-diffusion substrate.
 
-Wave 3b M2 — skeleton only. Houses the three building blocks that
-the public ``MLXLatentDiffusionSubstrate`` adapter wires together:
+Wave 3b M3 — building blocks + training loop + sampler. Houses
+the components that the public ``MLXLatentDiffusionSubstrate``
+adapter wires together :
 
 - ``Encoder``       (E) — awake activations → latent z
 - ``MLPDenoiser``   (U) — reverse-process denoiser network
 - ``NoiseSchedule`` (σ) — forward-process noise schedule
+- ``Sampler``           — DDPM reverse sampler (R1-clean keys)
+- ``Trainer``           — noise-prediction SGD loop (R1-clean keys)
 
-Training, sampling, and full DR-3 conformance wiring land in
-Wave 3b M3+. See ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
-§3.1 and §3.2 for the typed-primitives mapping.
+Full DR-3 conformance wiring lands via the public
+``MLXLatentDiffusionSubstrate`` adapter ; see
+``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+§3.1 / §3.2 for the typed-primitives mapping.
 """
 from __future__ import annotations
 
@@ -18,5 +22,13 @@ from kiki_oniric.substrates._diffusion.model import (
     MLPDenoiser,
     NoiseSchedule,
 )
+from kiki_oniric.substrates._diffusion.sampler import Sampler
+from kiki_oniric.substrates._diffusion.trainer import Trainer
 
-__all__ = ["Encoder", "MLPDenoiser", "NoiseSchedule"]
+__all__ = [
+    "Encoder",
+    "MLPDenoiser",
+    "NoiseSchedule",
+    "Sampler",
+    "Trainer",
+]

--- a/kiki_oniric/substrates/_diffusion/model.py
+++ b/kiki_oniric/substrates/_diffusion/model.py
@@ -1,98 +1,126 @@
-"""MLX latent-diffusion building blocks — skeleton (Wave 3b M2).
+"""MLX latent-diffusion building blocks (Wave 3b M3).
 
-This module defines the three core building blocks of the
-latent-diffusion substrate at **skeleton level**: typed signatures
-only, no training, no learned weights.
+The three core building blocks of the latent-diffusion substrate :
 
-- ``Encoder`` (E) — maps awake activations ``x`` to a latent
-  vector ``z``. Skeleton implementation returns a deterministic
-  zero-projection of the correct shape (no learned parameters
-  yet — those land in Wave 3b M3 alongside the trainer).
-- ``MLPDenoiser`` (U) — denoises a noisy latent ``z_t`` at
-  diffusion step ``t``. Skeleton implementation returns
-  ``zeros_like(z)`` to honour the typed signature without
-  committing to a training recipe.
-- ``NoiseSchedule`` (σ) — analytic linear-β schedule. ``sigma(t)``
-  and ``alpha_bar(t)`` ARE implemented (no learned weights
-  involved) so the §3.2 typing-table claim "7/8 typed"
-  is testable on real arrays in M3+.
+- :class:`Encoder` (E) — maps awake activations ``x`` to a latent
+  vector ``z`` via a single ``Linear`` + ReLU. ``train_step``
+  performs one SGD step on a reconstruction MSE objective against
+  the input (a deliberately weak self-supervised objective ; the
+  full encoder is M5-bench territory, this is the M3 R1-bootstrap
+  version).
+- :class:`MLPDenoiser` (U) — n-layer MLP that predicts the noise
+  added at a given diffusion timestep. ``train_step`` performs one
+  SGD step on a noise-prediction MSE objective.
+- :class:`NoiseSchedule` (σ) — analytic linear-β DDPM schedule.
+  No learned weights ; pre-computes β and ᾱ tables at construction.
 
-Methods that depend on M3 artefacts (training, sampling)
-raise ``NotImplementedError`` with a pointer to the milestone
-where they land. This is a deliberate contract: callers can
-import the classes and verify Protocol conformance today, but
-any attempt to *train* or *sample* surfaces the missing
-milestone explicitly rather than silently returning placeholder
-numbers.
+These classes are intentionally minimal. The R1 contract (plan
+§2.3 D3) is that *given the same MLX seed*, training and sampling
+are bit-identical on a fixed (MLX version, chip family) pair.
+
+The M2 skeleton returned ``zeros`` from the forward passes — the M3
+upgrade swaps in real ``nn.Linear`` weights so the training loop
+and the M3 R1 hashes have something non-trivial to bite into. The
+public ``__call__`` shape and dtype guarantees are unchanged.
 
 References:
 - ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
-  §3.1 (module layout) + §3.2 (typing table)
+  §3.1 (module layout) + §3.2 (typing table) + §4 M3
 - ``kiki_oniric/core/primitives.py`` (typed Protocols this
-  skeleton will eventually satisfy)
+  substrate satisfies via the M3 wiring)
 """
 from __future__ import annotations
 
+from typing import Any, cast
+
 import mlx.core as mx
+import mlx.nn as _nn
+
+# mlx.nn re-exports under a star pattern that mypy cannot resolve
+# (cf. ``tests/reproducibility/test_r1_bit_exact.py`` for the
+# precedent). We pin a local ``nn`` alias typed as ``Any`` so the
+# substrate code does not need per-line ``type: ignore`` annotations.
+nn: Any = cast(Any, _nn)
 
 
-class Encoder:
-    """E — Awake-side encoder: ``x`` (input batch) → ``z`` (latent).
+class Encoder(nn.Module):  # type: ignore[misc]
+    """E — Awake-side encoder ``x → z``.
 
-    Wave 3b M2 skeleton: the forward pass returns a deterministic
-    zero-projection of shape ``(batch, d_latent)``. No learned
-    weights, no training. The class exists so M3 can layer the
-    real linear+nonlinearity weights on top while keeping the
-    public signature ``__call__(x: mx.array) -> mx.array`` stable.
+    Single ``Linear(d_in → d_latent)`` + ReLU. A symmetric
+    reconstruction head ``Linear(d_latent → d_in)`` is used only
+    by :meth:`train_step` ; the public forward pass exposes only
+    the latent ``z``.
 
     Args:
         d_in: Input activation dimensionality.
-        d_latent: Output latent dimensionality. The plan's
-            D2 default is ``64`` and is enforced by the public
-            ``MLXLatentDiffusionSubstrate`` adapter.
+        d_latent: Output latent dimensionality. Plan D2 default ``64``.
     """
 
     def __init__(self, d_in: int, d_latent: int) -> None:
+        super().__init__()
         if d_in <= 0:
             raise ValueError(f"d_in must be positive, got {d_in}")
         if d_latent <= 0:
             raise ValueError(f"d_latent must be positive, got {d_latent}")
         self.d_in = d_in
         self.d_latent = d_latent
+        self.fc_enc = nn.Linear(d_in, d_latent)
+        self.fc_dec = nn.Linear(d_latent, d_in)
 
     def __call__(self, x: mx.array) -> mx.array:
-        """Return a zero latent of shape ``(batch, d_latent)``.
-
-        Skeleton-only: training, real linear projection, and
-        nonlinearity land in Wave 3b M3 (`_diffusion/trainer.py`).
-        """
+        """Project ``x`` (batch, d_in) → ``z`` (batch, d_latent)."""
         if x.ndim < 1:
             raise ValueError(
                 f"Encoder expects at least 1-D input, got ndim={x.ndim}"
             )
-        batch = x.shape[0] if x.ndim > 1 else 1
-        return mx.zeros((batch, self.d_latent), dtype=mx.float32)
+        if x.ndim == 1:
+            x = x[None, :]
+        out: mx.array = nn.relu(self.fc_enc(x))
+        return out
 
-    def train_step(self, *args: object, **kwargs: object) -> mx.array:
-        """Not implemented in M2.
+    def reconstruct(self, z: mx.array) -> mx.array:
+        """Decode the latent back to input space (training only)."""
+        out: mx.array = self.fc_dec(z)
+        return out
 
-        Training lands in Wave 3b M3 alongside
-        ``_diffusion/trainer.py`` (plan §4 M3).
+    def train_step(
+        self,
+        x: mx.array,
+        lr: float = 1e-3,
+    ) -> float:
+        """One SGD step on the reconstruction MSE ``|| dec(enc(x)) - x ||²``.
+
+        Returns the scalar loss (Python float) for logging /
+        deterministic R1 hashing. Reproducibility contract :
+        bit-identical given the same ``x``, ``lr`` and prior
+        weights on a fixed MLX version + chip family.
         """
-        raise NotImplementedError(
-            "Encoder.train_step is deferred to Wave 3b M3 "
-            "(_diffusion/trainer.py). M2 is skeleton-only."
-        )
+        if x.ndim < 1:
+            raise ValueError(
+                f"Encoder.train_step expects at least 1-D x, got ndim={x.ndim}"
+            )
+        if lr <= 0.0:
+            raise ValueError(f"lr must be positive, got {lr}")
+
+        def loss_fn(model: "Encoder", batch: mx.array) -> mx.array:
+            z = model(batch)
+            x_hat = model.reconstruct(z)
+            target = batch[None, :] if batch.ndim == 1 else batch
+            return mx.mean((x_hat - target) ** 2)
+
+        loss_and_grad = nn.value_and_grad(self, loss_fn)
+        loss, grads = loss_and_grad(self, x)
+        new_params = _sgd_apply(self.parameters(), grads, lr)
+        self.update(new_params)
+        return float(loss.item())
 
 
-class MLPDenoiser:
-    """U — MLP denoiser network ``(z_t, t) → ẑ_0``.
+class MLPDenoiser(nn.Module):  # type: ignore[misc]
+    """U — MLP denoiser network ``(z_t, t) → ε̂``.
 
-    Wave 3b M2 skeleton: the forward pass returns
-    ``mx.zeros_like(z_t)``. The class records ``d_latent``,
-    ``d_hidden`` and ``n_layers`` so M3 can materialize the
-    real MLP weights without changing the public signature
-    ``__call__(z: mx.array, t: mx.array) -> mx.array``.
+    n-layer MLP that predicts the noise added at diffusion step
+    ``t``. The timestep is broadcast as a scalar feature appended
+    to the latent on input.
 
     Args:
         d_latent: Latent dimensionality (must match ``Encoder.d_latent``).
@@ -106,6 +134,7 @@ class MLPDenoiser:
         d_hidden: int,
         n_layers: int = 3,
     ) -> None:
+        super().__init__()
         if d_latent <= 0:
             raise ValueError(f"d_latent must be positive, got {d_latent}")
         if d_hidden <= 0:
@@ -115,14 +144,16 @@ class MLPDenoiser:
         self.d_latent = d_latent
         self.d_hidden = d_hidden
         self.n_layers = n_layers
+        # Input concatenates the latent (d_latent) with the scalar
+        # timestep feature (1) ; output predicts the per-feature noise.
+        layers: list[Any] = [nn.Linear(d_latent + 1, d_hidden)]
+        for _ in range(n_layers - 1):
+            layers.append(nn.Linear(d_hidden, d_hidden))
+        layers.append(nn.Linear(d_hidden, d_latent))
+        self.layers = layers
 
     def __call__(self, z: mx.array, t: mx.array) -> mx.array:
-        """Return a zero denoised latent of shape ``z.shape``.
-
-        Skeleton-only: real weights + denoising trajectory land
-        in Wave 3b M3 (`_diffusion/trainer.py` +
-        `_diffusion/sampler.py`).
-        """
+        """Predict the noise added to ``z`` at step ``t``."""
         if z.ndim < 1:
             raise ValueError(
                 f"MLPDenoiser expects at least 1-D z, got ndim={z.ndim}"
@@ -131,29 +162,73 @@ class MLPDenoiser:
             raise ValueError(
                 f"MLPDenoiser expects at least 1-D t, got ndim={t.ndim}"
             )
-        return mx.zeros_like(z)
+        if z.ndim == 1:
+            z = z[None, :]
+        batch = z.shape[0]
+        # Broadcast t to (batch, 1) and concatenate to z along the
+        # feature axis. Accept either a scalar timestep (shape (1,))
+        # or a per-batch timestep (shape (batch,)).
+        if t.shape[0] == 1 and batch != 1:
+            t_feat = mx.broadcast_to(
+                t.astype(mx.float32)[:, None], (batch, 1)
+            )
+        else:
+            t_feat = t.astype(mx.float32).reshape(batch, 1)
+        h = mx.concatenate([z, t_feat], axis=-1)
+        for layer in self.layers[:-1]:
+            h = nn.relu(layer(h))
+        out: mx.array = self.layers[-1](h)
+        return out
 
-    def train_step(self, *args: object, **kwargs: object) -> mx.array:
-        """Not implemented in M2.
+    def train_step(
+        self,
+        z_clean: mx.array,
+        t: mx.array,
+        noise: mx.array,
+        schedule: "NoiseSchedule",
+        lr: float = 1e-3,
+    ) -> float:
+        """One SGD step on noise-prediction MSE ``|| ε̂(z_t, t) - ε ||²``.
 
-        Training lands in Wave 3b M3 alongside
-        ``_diffusion/trainer.py`` (plan §4 M3).
+        Args:
+            z_clean: Clean latent batch ``(batch, d_latent)``.
+            t: Per-batch timesteps ``(batch,)`` ``int32``.
+            noise: Standard normal noise of shape ``z_clean.shape``.
+            schedule: :class:`NoiseSchedule` providing ᾱ.
+            lr: SGD learning rate.
+
+        Returns:
+            Scalar loss (Python float).
         """
-        raise NotImplementedError(
-            "MLPDenoiser.train_step is deferred to Wave 3b M3 "
-            "(_diffusion/trainer.py). M2 is skeleton-only."
-        )
+        if lr <= 0.0:
+            raise ValueError(f"lr must be positive, got {lr}")
+
+        alpha_bar_t = schedule.alpha_bar(t)  # shape (batch,)
+        sqrt_ab = mx.sqrt(alpha_bar_t)[:, None]
+        sqrt_one_minus_ab = mx.sqrt(1.0 - alpha_bar_t)[:, None]
+        z_noisy = sqrt_ab * z_clean + sqrt_one_minus_ab * noise
+
+        def loss_fn(
+            model: "MLPDenoiser",
+            zn: mx.array,
+            tt: mx.array,
+            target: mx.array,
+        ) -> mx.array:
+            eps_hat = model(zn, tt)
+            return mx.mean((eps_hat - target) ** 2)
+
+        loss_and_grad = nn.value_and_grad(self, loss_fn)
+        loss, grads = loss_and_grad(self, z_noisy, t, noise)
+        new_params = _sgd_apply(self.parameters(), grads, lr)
+        self.update(new_params)
+        return float(loss.item())
 
 
 class NoiseSchedule:
     """σ — Linear-β forward noise schedule (DDPM-style).
 
     Implements the analytic ``β(t)``, ``α(t)``, and ``ᾱ(t)`` of
-    a linear-β DDPM forward process. No learned weights are
-    involved, so this is fully implemented in M2 — the typing
-    table (plan §3.2) needs at least one working primitive
-    on real arrays to keep the DR-3 "signature typing" angle
-    testable end-to-end before M3.
+    a linear-β DDPM forward process. No learned weights.
 
     Args:
         t_steps: Number of discrete diffusion timesteps.
@@ -177,9 +252,7 @@ class NoiseSchedule:
         self.t_steps = t_steps
         self.beta_min = beta_min
         self.beta_max = beta_max
-        # Pre-compute the linear-β schedule once. Shape (t_steps,).
         self._betas: mx.array = mx.linspace(beta_min, beta_max, t_steps)
-        # ᾱ(t) = ∏_{s<=t} (1 - β_s). Cumulative product.
         self._alpha_bars: mx.array = mx.cumprod(1.0 - self._betas)
 
     def _gather(self, table: mx.array, t: mx.array) -> mx.array:
@@ -199,3 +272,40 @@ class NoiseSchedule:
     def alpha_bar(self, t: mx.array) -> mx.array:
         """Return ``ᾱ(t) = ∏_{s<=t} (1 - β_s)`` at integer timesteps ``t``."""
         return self._gather(self._alpha_bars, t)
+
+
+def _sgd_apply(
+    params: object,
+    grads: object,
+    lr: float,
+) -> object:
+    """Apply a plain SGD update ``θ ← θ − lr · g`` element-wise.
+
+    Mirrors the tree structure of ``params`` / ``grads`` (both
+    nested ``dict`` / ``list`` of ``mx.array``). Uses
+    :func:`mlx.utils.tree_map` when available, with a manual
+    fallback for older MLX builds.
+    """
+    try:
+        from mlx.utils import tree_map
+    except ImportError:  # pragma: no cover — fallback for very old MLX
+        return _sgd_apply_manual(params, grads, lr)
+
+    def _step(p: mx.array, g: mx.array) -> mx.array:
+        return p - lr * g
+
+    return tree_map(_step, params, grads)
+
+
+def _sgd_apply_manual(  # pragma: no cover — fallback only
+    params: object,
+    grads: object,
+    lr: float,
+) -> object:
+    if isinstance(params, dict) and isinstance(grads, dict):
+        return {k: _sgd_apply_manual(params[k], grads[k], lr) for k in params}
+    if isinstance(params, list) and isinstance(grads, list):
+        return [_sgd_apply_manual(p, g, lr) for p, g in zip(params, grads)]
+    if hasattr(params, "shape"):
+        return params - lr * grads  # type: ignore[operator]
+    return params

--- a/kiki_oniric/substrates/_diffusion/sampler.py
+++ b/kiki_oniric/substrates/_diffusion/sampler.py
@@ -1,0 +1,180 @@
+"""DDPM reverse-process sampler with an R1-clean key derivation tree.
+
+Wave 3b M3 (per plan §4 M3 + §2.3 D3).
+
+The sampler implements the standard DDPM reverse update :
+
+    x_{t-1} = (1 / sqrt(alpha_t)) * (x_t - (beta_t / sqrt(1 - alpha_bar_t)) * eps_theta(x_t, t))
+              + sigma_t * z,        z ~ N(0, I)
+
+where ``eps_theta`` is the trained :class:`MLPDenoiser` and the
+schedule values come from :class:`NoiseSchedule`. The skeleton
+:class:`MLPDenoiser` returns ``zeros_like(z)`` so the sampler is
+exercisable end-to-end against the M2 weights without committing
+to a particular trained model. M3+ swaps in real denoiser weights
+without changing the public surface.
+
+R1 contract (per plan §2.3 D3).
+================================
+
+The sampler MUST consume only ``mx.random.split``-derived keys, and
+NEVER a raw ``mx.random.key(seed)`` passed straight to
+``mx.random.normal``. The cross-machine probe (2026-05-20,
+``docs/milestones/r1-cross-machine-m5-vs-m1-2026-05-20.md``) showed
+that raw-key consumption diverges on M1 Max while split-derived
+keys reproduce across all Apple Silicon variants tested.
+
+Key derivation is therefore :
+
+    root_key                 = caller-provided ``mx.array``
+    subkeys (n_steps + 1)    = ``mx.random.split(root_key, num=n_steps + 1)``
+    subkeys[0]               = reserved (do not consume) — separates
+                               the root-key shape from the first
+                               step-key draw so the per-step
+                               consumption pattern stays uniform.
+    subkeys[t + 1]           = key for reverse step ``t`` (``t`` in
+                               ``[0, n_steps)``)
+
+Determinism guarantees (given a fixed MLX version + chip family) :
+
+* same ``root_key`` + ``n_steps`` + ``shape`` → bit-identical
+  output ``mx.array``.
+* different ``root_key`` (any flip) → different output (with
+  overwhelming probability ; the test asserts inequality on a
+  non-zero element of the diff).
+* ``shape`` invariance : the output has exactly the requested
+  ``shape``.
+
+These guarantees are exercised by
+``tests/unit/test_diffusion_sampler_keys.py``.
+
+References
+----------
+- ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+  §2.3 D3 (R1 key derivation), §3.1 (module layout), §4 M3
+  (this file's milestone).
+- Ho, Jain, Abbeel (2020) — *Denoising Diffusion Probabilistic
+  Models*, arXiv 2006.11239, §3.2 (reverse process), Algorithm 2
+  (sampling).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import mlx.core as mx
+else:
+    import mlx.core as mx  # noqa: F401 — re-imported at runtime
+
+from kiki_oniric.substrates._diffusion.model import (
+    MLPDenoiser,
+    NoiseSchedule,
+)
+
+
+class Sampler:
+    """DDPM reverse-process sampler bound to a denoiser + schedule.
+
+    The sampler is intentionally a thin object : the denoiser and
+    schedule own their respective state (weights, β/ᾱ tables) and
+    the sampler is responsible only for the reverse-update loop
+    and the R1-clean key-derivation tree (§2.3 D3).
+
+    Args:
+        model: Trained (or skeleton) :class:`MLPDenoiser`. Must
+            satisfy ``__call__(z: mx.array, t: mx.array) -> mx.array``
+            returning an estimate of the noise added to ``z``.
+        schedule: :class:`NoiseSchedule` with at least as many
+            timesteps as the ``n_steps`` requested at sample time.
+    """
+
+    def __init__(self, model: MLPDenoiser, schedule: NoiseSchedule) -> None:
+        self.model = model
+        self.schedule = schedule
+
+    def sample(
+        self,
+        key: "mx.array",
+        n_steps: int,
+        shape: tuple[int, ...],
+    ) -> "mx.array":
+        """Run ``n_steps`` of the DDPM reverse process from pure noise.
+
+        Args:
+            key: Root ``mx.array`` key (typically
+                ``mx.random.key(cell_seed)``). Consumed only via
+                :func:`mx.random.split` per the R1 contract.
+            n_steps: Number of reverse steps. Must be in
+                ``[1, schedule.t_steps]``.
+            shape: Output shape (e.g. ``(batch, d_latent)``).
+
+        Returns:
+            A sample ``mx.array`` of the requested ``shape``.
+
+        Raises:
+            ValueError: if ``n_steps`` is non-positive or exceeds
+                the schedule's ``t_steps``, or if ``shape`` is empty.
+        """
+        if n_steps <= 0:
+            raise ValueError(f"n_steps must be positive, got {n_steps}")
+        if n_steps > self.schedule.t_steps:
+            raise ValueError(
+                f"n_steps={n_steps} exceeds schedule.t_steps="
+                f"{self.schedule.t_steps}"
+            )
+        if len(shape) == 0:
+            raise ValueError("shape must be non-empty")
+
+        # Derive a per-step subkey tree using split — never a raw key
+        # straight to mx.random.normal (per R1 §2.3 D3).
+        # We request n_steps + 1 subkeys ; subkeys[0] is reserved
+        # (initial-noise draw) and subkeys[1..n_steps] feed the
+        # reverse-step stochastic draws.
+        subkeys = mx.random.split(key, num=n_steps + 1)
+
+        # Sample x_T ~ N(0, I) using the reserved subkey.
+        x = mx.random.normal(shape=shape, key=subkeys[0])
+
+        # Reverse loop : t goes n_steps-1 → 0 (the standard DDPM
+        # iteration order). Each step pulls its noise draw from the
+        # corresponding split-derived subkey to keep the key tree
+        # deterministic and cross-machine-stable.
+        for step in range(n_steps):
+            t_value = n_steps - 1 - step
+            t_arr = mx.array([t_value], dtype=mx.int32)
+
+            # Denoiser estimate of the noise added at step t.
+            eps_hat = self.model(x, t_arr)
+
+            # Schedule lookups : alpha_bar_t and beta_t. The
+            # NoiseSchedule API returns alpha_bar(t) ; we recover
+            # alpha_t and beta_t from the pre-computed tables via
+            # the public accessors only.
+            alpha_bar_t = self.schedule.alpha_bar(t_arr)
+            beta_t = self.schedule.sigma(t_arr) ** 2  # sigma = sqrt(beta)
+            alpha_t = 1.0 - beta_t
+
+            # DDPM reverse mean.
+            coef_eps = beta_t / mx.sqrt(1.0 - alpha_bar_t)
+            mean = (x - coef_eps * eps_hat) / mx.sqrt(alpha_t)
+
+            if t_value > 0:
+                noise = mx.random.normal(shape=shape, key=subkeys[step + 1])
+                sigma_t = self.schedule.sigma(t_arr)
+                x = mean + sigma_t * noise
+            else:
+                # At t=0 the standard DDPM update drops the stochastic
+                # tail, returning the mean as the final sample.
+                x = mean
+
+        # Defensive shape check : the reverse loop must not change
+        # the requested shape (it does not, but assert it cheaply).
+        if tuple(x.shape) != tuple(shape):
+            raise RuntimeError(
+                f"Sampler produced shape {tuple(x.shape)} "
+                f"!= requested shape {tuple(shape)}"
+            )
+        return x
+
+
+__all__ = ["Sampler"]

--- a/kiki_oniric/substrates/_diffusion/trainer.py
+++ b/kiki_oniric/substrates/_diffusion/trainer.py
@@ -1,0 +1,164 @@
+"""Training loop for the MLX latent-diffusion substrate (Wave 3b M3).
+
+Provides :class:`Trainer`, a thin wrapper that runs noise-prediction
+SGD on :class:`MLPDenoiser` against samples drawn from a
+caller-provided latent dataset. The trainer owns the per-step
+random-key tree but never owns model weights — those live on the
+:class:`MLPDenoiser` instance the caller passes in.
+
+R1 contract (per plan §2.3 D3).
+================================
+
+Training MUST consume only ``mx.random.split``-derived keys, never
+a raw ``mx.random.key(seed)`` value passed straight to
+``mx.random.normal``. The per-step subkey tree is :
+
+    seed_key                = caller-provided ``mx.array``
+    subkeys (n_total + 1)   = ``mx.random.split(seed_key, num=n_total + 1)``
+                              with ``n_total = n_epochs * steps_per_epoch``
+    subkeys[0]              = reserved (matches sampler's reservation)
+    subkeys[i + 1]          = key for the (i+1)-th training step
+                              (epoch * steps_per_epoch + step)
+
+Determinism guarantees (given a fixed MLX version + chip family) :
+
+* same ``dataset`` (identical bytes, identical iteration order),
+  same ``n_epochs``, same ``seed_key`` → bit-identical loss history.
+* the loss history is the contract surface for the R1 hash ; weight
+  hashes are an additional layer captured in
+  ``tests/reproducibility/test_r1_diffusion.py``.
+
+References
+----------
+- ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
+  §2.3 D3 (R1 key derivation), §3.1 (module layout), §4 M3
+  (this file's milestone).
+- Ho, Jain, Abbeel (2020) — *Denoising Diffusion Probabilistic
+  Models*, arXiv 2006.11239, §3.2 (training objective),
+  Algorithm 1 (training loop).
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import mlx.core as mx
+
+from kiki_oniric.substrates._diffusion.model import (
+    MLPDenoiser,
+    NoiseSchedule,
+)
+
+
+class Trainer:
+    """Noise-prediction SGD trainer for :class:`MLPDenoiser`.
+
+    Args:
+        model: :class:`MLPDenoiser` to train (in-place updates).
+        schedule: :class:`NoiseSchedule` providing ᾱ for the
+            forward-noising step in the DDPM training objective.
+        optimizer_kwargs: ``{"lr": float}`` ; reserved for future
+            optimizer choices (currently SGD-only).
+    """
+
+    def __init__(
+        self,
+        model: MLPDenoiser,
+        schedule: NoiseSchedule,
+        optimizer_kwargs: dict[str, float] | None = None,
+    ) -> None:
+        self.model = model
+        self.schedule = schedule
+        opts = dict(optimizer_kwargs or {})
+        self.lr: float = float(opts.pop("lr", 1e-3))
+        if self.lr <= 0.0:
+            raise ValueError(f"lr must be positive, got {self.lr}")
+        if opts:
+            raise ValueError(
+                f"Unsupported optimizer_kwargs keys : {sorted(opts)}"
+            )
+
+    def train_step(
+        self,
+        batch: mx.array,
+        key: mx.array,
+    ) -> dict[str, float]:
+        """Run one SGD step on ``batch`` using ``key`` for noise sampling.
+
+        Args:
+            batch: Clean latents ``(batch, d_latent)``.
+            key: Split-derived MLX key for the noise + timestep
+                draws (per the R1 contract).
+
+        Returns:
+            ``{"loss": float}`` dict for logging / R1 hashing.
+        """
+        if batch.ndim < 2:
+            raise ValueError(
+                f"Trainer.train_step expects 2-D batch, got ndim={batch.ndim}"
+            )
+
+        # Two sub-keys : one for timestep sampling, one for noise.
+        noise_key, t_key = mx.random.split(key, num=2)
+
+        n = batch.shape[0]
+        t = mx.random.randint(
+            low=0, high=self.schedule.t_steps, shape=(n,), key=t_key
+        ).astype(mx.int32)
+        noise = mx.random.normal(shape=batch.shape, key=noise_key)
+
+        loss = self.model.train_step(
+            batch, t, noise, self.schedule, lr=self.lr
+        )
+        return {"loss": loss}
+
+    def fit(
+        self,
+        dataset: Iterable[mx.array],
+        n_epochs: int,
+        seed_key: mx.array,
+    ) -> dict[str, list[float]]:
+        """Train for ``n_epochs`` over ``dataset`` using ``seed_key``.
+
+        The dataset MUST be re-iterable (list-like or generator
+        factory result) — the trainer iterates it once per epoch.
+        The number of steps per epoch is inferred as the length of
+        the materialized list of batches on the first epoch.
+
+        Args:
+            dataset: Iterable of batches ``(batch, d_latent)``.
+            n_epochs: Number of epochs.
+            seed_key: Root MLX key. The trainer derives all per-step
+                sub-keys via :func:`mx.random.split` per §2.3 D3.
+
+        Returns:
+            ``{"loss": [...]}`` list of per-step losses across all
+            epochs (length ``n_epochs * steps_per_epoch``).
+        """
+        if n_epochs <= 0:
+            raise ValueError(f"n_epochs must be positive, got {n_epochs}")
+
+        # Materialize once : we need a deterministic ordering and
+        # steps_per_epoch for the subkey tree.
+        batches: list[mx.array] = list(dataset)
+        if len(batches) == 0:
+            raise ValueError("dataset must yield at least one batch")
+        steps_per_epoch = len(batches)
+        n_total = n_epochs * steps_per_epoch
+
+        # Derive the per-step subkey tree. We request ``n_total + 1``
+        # subkeys ; subkeys[0] is reserved (matches the sampler
+        # reservation pattern) and subkeys[i+1] feeds the i-th step.
+        subkeys = mx.random.split(seed_key, num=n_total + 1)
+
+        losses: list[float] = []
+        step_index = 0
+        for _ in range(n_epochs):
+            for batch in batches:
+                step_key = subkeys[step_index + 1]
+                metrics = self.train_step(batch, step_key)
+                losses.append(metrics["loss"])
+                step_index += 1
+        return {"loss": losses}
+
+
+__all__ = ["Trainer"]

--- a/kiki_oniric/substrates/mlx_latent_diffusion.py
+++ b/kiki_oniric/substrates/mlx_latent_diffusion.py
@@ -1,48 +1,56 @@
-"""MLX latent-diffusion substrate adapter — Wave 3b M2 skeleton.
+"""MLX latent-diffusion substrate adapter — Wave 3b M3.
 
 Fourth member of the substrate family, alongside
 ``mlx_kiki_oniric``, ``esnn_thalamocortical``, and ``micro_kiki``.
-This file is the **public adapter** that wires the three building
-blocks (``Encoder``, ``MLPDenoiser``, ``NoiseSchedule``) into the
-substrate ABI consumed by ``DreamRuntime.execute()`` via the
-``SubstrateAdapter`` Protocol defined in
-``kiki_oniric/substrates/factory.py``.
+This file is the **public adapter** that wires the building
+blocks (``Encoder``, ``MLPDenoiser``, ``NoiseSchedule``,
+``Trainer``, ``Sampler``) into the substrate ABI consumed by
+``DreamRuntime.execute()`` via the ``SubstrateAdapter`` Protocol
+defined in ``kiki_oniric/substrates/factory.py``.
 
-Wave 3b M2 scope (this file):
+Wave 3b M3 scope (this file):
 - Public class ``MLXLatentDiffusionSubstrate`` instantiable with
   the D2 defaults (``d_latent=64``, ``n_layers=3``) per the plan.
-- ``SubstrateAdapter`` Protocol surface present: ``execute_profile``
-  and ``teardown`` typed at the skeleton level.
-- ``NotImplementedError`` raised on any operation that requires
-  training, sampling, or registry I/O — those land in Wave 3b M3+.
-
-The Track S vs Track B decision (full DR-3 conformance vs
-baseline-only adapter, per plan §1.2) is **deferred to PR review**.
-This file is scope-neutral: it does not add conformance test
-artefacts, and it does not commit to a baseline rebrand.
+- ``SubstrateAdapter`` Protocol surface ``execute_profile`` /
+  ``teardown`` now wires a real (short) training + sampling pass
+  for ablation_cycle3 smoke runs (M4 will plug the CIFAR-100
+  loader ; M3 ships a deterministic synthetic-latent driver so
+  the substrate is exercised end-to-end and R1-hashable today).
+- ``Track S`` chosen at the M2 review : DR-3 conformance tests
+  land under ``tests/conformance/axioms/`` in this PR.
 
 References:
 - ``docs/plans/2026-05-20-wave3b-mlx-diffusion-substrate-plan.md``
-  §3.1 (module layout) + §3.3 (factory integration) + §4 M2
+  §3.1 (module layout) + §3.3 (factory integration) + §4 M3
 - ``kiki_oniric/substrates/factory.py`` (``SubstrateAdapter`` Protocol)
 - ``kiki_oniric/substrates/mlx_kiki_oniric.py`` (sibling pattern)
 """
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from kiki_oniric.substrates._diffusion import (
     Encoder,
     MLPDenoiser,
     NoiseSchedule,
+    Sampler,
+    Trainer,
 )
+
+if TYPE_CHECKING:
+    from kiki_oniric.substrates.factory import CellRequest
 
 
 # Substrate identity (mirrors the cycle-1/2/3 substrate identity blocks).
 MLX_LATENT_DIFFUSION_SUBSTRATE_NAME = "mlx_latent_diffusion"
-# DualVer empirical axis : Wave 3b skeleton ships at PARTIAL until the
-# M3 trainer + M5 full bench land. Bump rules per framework-C §12.
-MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION = "C-v0.13.0+PARTIAL"
+# DualVer empirical axis : Wave 3b PARTIAL until the M5 full bench
+# closes. Bump rules per framework-C §12.
+# M2 → M3 substrate-internal MINOR : C-v0.13.0 → C-v0.14.0 (trainer +
+# sampler + R1 entries shipped). EC stays PARTIAL ; M6 will flip to
+# STABLE iff §12.3 conditions all hold.
+MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION = "C-v0.14.0+PARTIAL"
 
 # D2 defaults from the plan (§2.2, blocker D2 resolved at M1).
 _DEFAULT_D_LATENT = 64
@@ -128,19 +136,89 @@ class MLXLatentDiffusionSubstrate:
     # SubstrateAdapter Protocol surface (factory.py).
     # ------------------------------------------------------------------
 
-    def execute_profile(self, request: object) -> dict[str, object]:
-        """Run pre-eval → dream ops → post-eval for one cell.
+    def execute_profile(self, request: "CellRequest | object") -> dict[str, object]:
+        """Run a minimal train + sample cycle for one ablation cell.
 
-        Wave 3b M2 skeleton: not implemented. The dream-ops
-        wiring (replay / downscale / restructure / recombine
-        translated into diffusion train + sample steps) lands
-        in Wave 3b M3 with the trainer + sampler. See plan §4 M3.
+        Wave 3b M3 wiring (synthetic-latent driver, M4 will swap in
+        the CIFAR-100 loader). The cycle :
+
+        1. Seed MLX RNG from ``request.seed`` so the synthetic
+           training latents and the per-step subkey trees are
+           deterministic.
+        2. Build a small synthetic dataset of normal latents.
+        3. Run a short :class:`Trainer.fit` on the denoiser
+           (noise-prediction MSE).
+        4. Draw one reverse-process sample via :class:`Sampler`.
+        5. Return a metrics dict shaped like the sibling
+           substrates (``replay_rate`` / ``downscale_norm`` etc.
+           proxied from the trainer + sampler state) so the
+           ablation_cycle3 row reducer accepts it without a
+           schema branch.
+
+        The output is intentionally a self-contained smoke trace
+        — the bench-grade objective lands in M5. The
+        ``synthetic`` marker in the returned dict makes that
+        explicit per CLAUDE.md §Working rules item 3.
         """
-        raise NotImplementedError(
-            "MLXLatentDiffusionSubstrate.execute_profile is deferred "
-            "to Wave 3b M3 (trainer + sampler + ablation_cycle3 "
-            "integration). M2 ships skeleton + Protocol conformance only."
+        import mlx.core as mx
+
+        seed = int(getattr(request, "seed", 0))
+        # Per the R1 contract : derive the training and sampling
+        # root keys from one split of the seed key. Never consume
+        # a raw mx.random.key(seed) directly with mx.random.normal.
+        root = mx.random.key(seed)
+        train_root, sample_root, data_root = mx.random.split(root, num=3)
+
+        # Tiny synthetic latent dataset : 4 batches × batch_size 8.
+        # Held small so the M3 smoke fits in seconds on M5.
+        d_latent = self.config.d_latent
+        n_batches = 4
+        batch_size = 8
+        data_keys = mx.random.split(data_root, num=n_batches)
+        dataset = [
+            mx.random.normal(shape=(batch_size, d_latent), key=k)
+            for k in data_keys
+        ]
+
+        t0 = time.perf_counter()
+
+        trainer = Trainer(
+            model=self.denoiser,
+            schedule=self.schedule,
+            optimizer_kwargs={"lr": 1e-3},
         )
+        history = trainer.fit(
+            dataset=dataset, n_epochs=1, seed_key=train_root
+        )
+        losses = history["loss"]
+
+        sampler = Sampler(model=self.denoiser, schedule=self.schedule)
+        sample = sampler.sample(
+            key=sample_root,
+            n_steps=min(8, self.schedule.t_steps),
+            shape=(1, d_latent),
+        )
+
+        wall = time.perf_counter() - t0
+        # Convert to plain Python floats so the row reducer can
+        # serialize without an MLX dependency.
+        loss_first = float(losses[0]) if losses else 0.0
+        loss_last = float(losses[-1]) if losses else 0.0
+        sample_norm = float(mx.sqrt(mx.sum(sample * sample)).item())
+
+        return {
+            "replay_rate": loss_last,       # proxy : trained denoiser loss
+            "downscale_norm": sample_norm,  # proxy : sample magnitude
+            "restructure_sum": 0.0,         # canal 3 inactive in smoke
+            "recombine_rate": float(len(losses)),
+            "delta_acc": loss_first - loss_last,
+            "wall_time_s": wall,
+            "synthetic": True,
+            "profile": getattr(request, "profile", "unknown"),
+            "seed": seed,
+            "substrate": MLX_LATENT_DIFFUSION_SUBSTRATE_NAME,
+            "substrate_version": MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION,
+        }
 
     def teardown(self) -> None:
         """Release MLX Metal buffers / close files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreamofkiki"
-version = "0.21.0"
+version = "0.22.0"
 description = "Substrate-agnostic formal framework for dream-based knowledge consolidation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/conformance/axioms/test_dr0_diffusion_de_budget.py
+++ b/tests/conformance/axioms/test_dr0_diffusion_de_budget.py
@@ -1,0 +1,92 @@
+"""DR-0 Accountability — MLX latent-diffusion substrate (Wave 3b M3).
+
+Substrate-side translation of DR-0 (every executed DE appears in
+the runtime log with a finite budget) :
+
+* Every training step counts as one DE. The Trainer's ``fit``
+  produces exactly ``n_epochs * steps_per_epoch`` loss entries
+  (accountable record).
+* The per-DE budget (loss is finite, runtime is bounded by the
+  caller-supplied ``n_epochs``) is enforced.
+
+Reference: docs/specs/2026-04-17-dreamofkiki-framework-C-design.md §6.2
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+mx = pytest.importorskip("mlx.core")
+
+from kiki_oniric.substrates._diffusion import (  # noqa: E402
+    MLPDenoiser,
+    NoiseSchedule,
+    Trainer,
+)
+
+
+def _build_trainer(d_latent: int = 4) -> Trainer:
+    mx.random.seed(0)
+    denoiser = MLPDenoiser(d_latent=d_latent, d_hidden=8, n_layers=2)
+    schedule = NoiseSchedule(t_steps=16, beta_min=1e-4, beta_max=2e-2)
+    return Trainer(model=denoiser, schedule=schedule)
+
+
+@given(
+    n_epochs=st.integers(min_value=1, max_value=4),
+    n_batches=st.integers(min_value=1, max_value=4),
+    batch_size=st.integers(min_value=1, max_value=4),
+)
+@settings(max_examples=10, deadline=None, derandomize=True)
+def test_dr0_loss_history_length_matches_de_count(
+    n_epochs: int, n_batches: int, batch_size: int
+) -> None:
+    """Loss history length == ``n_epochs * n_batches`` (DR-0 accounting)."""
+    trainer = _build_trainer()
+    root = mx.random.key(11)
+    data_keys = mx.random.split(root, num=n_batches)
+    dataset = [
+        mx.random.normal(shape=(batch_size, 4), key=k) for k in data_keys
+    ]
+    history = trainer.fit(dataset=dataset, n_epochs=n_epochs, seed_key=root)
+    assert len(history["loss"]) == n_epochs * n_batches
+
+
+def test_dr0_each_de_loss_is_finite_and_non_negative() -> None:
+    """Every DE in the log carries a finite, non-negative loss (S2 + DR-0)."""
+    trainer = _build_trainer()
+    root = mx.random.key(13)
+    data_keys = mx.random.split(root, num=3)
+    dataset = [
+        mx.random.normal(shape=(2, 4), key=k) for k in data_keys
+    ]
+    losses = trainer.fit(
+        dataset=dataset, n_epochs=2, seed_key=root
+    )["loss"]
+    assert len(losses) == 6
+    for loss in losses:
+        assert math.isfinite(loss)
+        assert loss >= 0.0
+
+
+def test_dr0_trainer_rejects_zero_epochs() -> None:
+    """DR-0 budget cap : ``n_epochs`` MUST be positive."""
+    trainer = _build_trainer()
+    with pytest.raises(ValueError, match="n_epochs"):
+        trainer.fit(
+            dataset=[mx.zeros((1, 4), dtype=mx.float32)],
+            n_epochs=0,
+            seed_key=mx.random.key(0),
+        )
+
+
+def test_dr0_trainer_rejects_empty_dataset() -> None:
+    """DR-0 budget cap : the dataset MUST yield at least one batch."""
+    trainer = _build_trainer()
+    with pytest.raises(ValueError, match="at least one batch"):
+        trainer.fit(
+            dataset=[], n_epochs=1, seed_key=mx.random.key(0)
+        )

--- a/tests/conformance/axioms/test_dr1_diffusion_finite.py
+++ b/tests/conformance/axioms/test_dr1_diffusion_finite.py
@@ -1,0 +1,90 @@
+"""DR-1 Finiteness — MLX latent-diffusion substrate (Wave 3b M3).
+
+Substrate-side translation of DR-1 (every episodic record is
+eventually consumed by a DE) :
+
+* Every batch in the trainer's dataset MUST be consumed exactly
+  ``n_epochs`` times (no leakage, no replay-amplification beyond
+  the declared epoch count).
+* Training MUST terminate in a bounded number of steps (no
+  infinite loop).
+* The sampler MUST terminate in exactly ``n_steps`` reverse
+  iterations.
+
+Reference: docs/specs/2026-04-17-dreamofkiki-framework-C-design.md §6.2
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from kiki_oniric.substrates._diffusion import (  # noqa: E402
+    MLPDenoiser,
+    NoiseSchedule,
+    Sampler,
+    Trainer,
+)
+
+
+def _build_pair(
+    d_latent: int = 4, t_steps: int = 8
+) -> tuple[Trainer, Sampler]:
+    mx.random.seed(0)
+    denoiser = MLPDenoiser(d_latent=d_latent, d_hidden=8, n_layers=2)
+    schedule = NoiseSchedule(t_steps=t_steps, beta_min=1e-4, beta_max=2e-2)
+    return Trainer(model=denoiser, schedule=schedule), Sampler(
+        model=denoiser, schedule=schedule
+    )
+
+
+def test_dr1_training_terminates_in_finite_steps() -> None:
+    """Training MUST terminate ; total step count is bounded."""
+    trainer, _ = _build_pair()
+    root = mx.random.key(0)
+    data_keys = mx.random.split(root, num=2)
+    dataset = [mx.random.normal(shape=(2, 4), key=k) for k in data_keys]
+    history = trainer.fit(dataset=dataset, n_epochs=3, seed_key=root)
+    # Strict upper bound : 3 epochs × 2 batches = 6 steps.
+    assert len(history["loss"]) <= 6
+
+
+def test_dr1_sampler_terminates_in_exactly_n_steps() -> None:
+    """The sampler returns after exactly ``n_steps`` iterations.
+
+    Negative witness : there is no inner unbounded loop. We probe
+    by asserting termination at multiple ``n_steps`` values.
+    """
+    _, sampler = _build_pair()
+    for n_steps in (1, 2, 4, 8):
+        out = sampler.sample(
+            key=mx.random.key(0), n_steps=n_steps, shape=(1, 4)
+        )
+        assert tuple(out.shape) == (1, 4)
+
+
+def test_dr1_every_batch_consumed_n_epochs_times() -> None:
+    """Conservation : steps_per_epoch * n_epochs == loss-history length.
+
+    No batch leaks (no over-consumption), no batch is silently
+    dropped (no under-consumption).
+    """
+    trainer, _ = _build_pair()
+    root = mx.random.key(0)
+    data_keys = mx.random.split(root, num=4)
+    dataset = [mx.random.normal(shape=(1, 4), key=k) for k in data_keys]
+    history = trainer.fit(dataset=dataset, n_epochs=2, seed_key=root)
+    assert len(history["loss"]) == len(dataset) * 2
+
+
+def test_dr1_all_losses_finite() -> None:
+    """No NaN / Inf in the loss trace (S2-aligned guard for DR-1)."""
+    trainer, _ = _build_pair()
+    root = mx.random.key(0)
+    data_keys = mx.random.split(root, num=3)
+    dataset = [mx.random.normal(shape=(2, 4), key=k) for k in data_keys]
+    losses = trainer.fit(dataset=dataset, n_epochs=1, seed_key=root)["loss"]
+    for loss in losses:
+        assert math.isfinite(loss)

--- a/tests/conformance/axioms/test_dr3_diffusion_substrate.py
+++ b/tests/conformance/axioms/test_dr3_diffusion_substrate.py
@@ -1,0 +1,229 @@
+"""DR-3 Conformance Criterion — MLX latent-diffusion substrate (Wave 3b).
+
+Validates that the latent-diffusion substrate satisfies the 3
+conditions of the DR-3 Conformance Criterion (framework-C spec
+§6.2) :
+
+1. **Signature typing** — substrate exports the identity constants
+   and a callable adapter ; the 7/8 typed primitives mapping (plan
+   §3.2) is exercised by walking the public surface
+   ``MLXLatentDiffusionSubstrate.execute_profile`` returns. Canal 4
+   is the documented no-op (flat latent space) and is asserted as
+   such — the criterion permits a *typed-but-empty* return for the
+   no-op primitive (framework-C §6.2).
+
+2. **Axiom property tests** — DR-0 budget accountability is tested
+   via the smoke cycle's deterministic step-count ; DR-1 finite-loss
+   propagation is tested via the loss-history return ; DR-2'
+   canonical-order determinism is tested via repeated identical
+   execution.
+
+3. **BLOCKING invariants enforceable** — S2 (finite values) on the
+   trainer loss and the sampler output ; S3 (topology) is N/A for
+   this substrate (no graph mutation), explicitly documented.
+
+Reference : docs/specs/2026-04-17-dreamofkiki-framework-C-design.md §6.2
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from kiki_oniric.substrates._diffusion import (  # noqa: E402
+    Encoder,
+    MLPDenoiser,
+    NoiseSchedule,
+    Sampler,
+    Trainer,
+)
+from kiki_oniric.substrates.factory import (  # noqa: E402
+    SUBSTRATE_NAMES,
+    build_substrate_adapter,
+)
+from kiki_oniric.substrates.mlx_latent_diffusion import (  # noqa: E402
+    MLX_LATENT_DIFFUSION_SUBSTRATE_NAME,
+    MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION,
+    MLXLatentDiffusionSubstrate,
+)
+
+
+@dataclass
+class _StubRequest:
+    seed: int = 7
+    profile: str = "p_min"
+
+
+# ===== Condition 1 : signature typing =====
+
+
+def test_c1_substrate_exports_required_identity_constants() -> None:
+    """Identity constants follow the substrate naming convention."""
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_NAME == "mlx_latent_diffusion"
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION.startswith("C-v")
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION.endswith("+PARTIAL")
+    assert MLX_LATENT_DIFFUSION_SUBSTRATE_NAME in SUBSTRATE_NAMES
+
+
+def test_c1_factory_returns_substrate_for_canonical_name() -> None:
+    """Factory dispatch wires the substrate by its canonical name."""
+    adapter = build_substrate_adapter("mlx_latent_diffusion")
+    assert isinstance(adapter, MLXLatentDiffusionSubstrate)
+
+
+def test_c1_typed_primitives_7_of_8() -> None:
+    """The 7 typed primitives (plan §3.2) each have a callable
+    correspondent in the substrate surface. The 8th (Canal 4,
+    ``AttentionPriorChannel``) is the documented no-op.
+
+    We exercise each typed primitive by asserting the relevant
+    M3 building block exposes the expected callable :
+
+    * α (AlphaStreamProtocol)    → ``Encoder.__call__``
+    * β (BetaBufferProtocol)     → adapter-level dataset feed (the
+                                    Trainer accepts batches of latents
+                                    consumed in FIFO order)
+    * γ (GammaSnapshotProtocol)  → ``MLPDenoiser`` parameter readout
+                                    (snapshotable via .parameters())
+    * δ (DeltaLatentsProtocol)   → ``MLPDenoiser`` internal activations
+                                    available via the forward call
+    * Canal 1 (WeightDelta)      → ``MLPDenoiser.train_step``
+    * Canal 2 (LatentSample)     → ``Sampler.sample``
+    * Canal 3 (HierarchyChange)  → adapter-level restructure no-op
+                                    (typed at the substrate Protocol
+                                    surface ; the latent-MLP has no
+                                    explicit graph but the contract
+                                    accepts an empty diff list)
+    """
+    adapter = MLXLatentDiffusionSubstrate()
+    # α — encoder forward call.
+    assert callable(adapter.encoder.__call__)
+    # γ — denoiser parameters are readable for snapshotting.
+    params = adapter.denoiser.parameters()
+    assert params is not None
+    # δ — denoiser forward call.
+    assert callable(adapter.denoiser.__call__)
+    # Canal 1 — denoiser training step.
+    assert callable(adapter.denoiser.train_step)
+    # Canal 2 — sampler is constructible from the adapter's
+    # building blocks.
+    sampler = Sampler(model=adapter.denoiser, schedule=adapter.schedule)
+    assert callable(sampler.sample)
+    # β — trainer accepts a batch dataset (FIFO buffer surrogate).
+    trainer = Trainer(
+        model=adapter.denoiser,
+        schedule=adapter.schedule,
+    )
+    assert callable(trainer.fit)
+    assert callable(trainer.train_step)
+    # Canal 3 — empty topology-diff acceptance : the adapter's
+    # public surface returns a "restructure_sum" key set to 0.0
+    # in the M3 smoke cycle, mirroring the typed-but-empty
+    # contract for a flat latent space.
+    out = adapter.execute_profile(_StubRequest())
+    assert "restructure_sum" in out
+    assert out["restructure_sum"] == 0.0
+
+
+def test_c1_canal_4_attention_prior_is_documented_noop() -> None:
+    """Canal 4 (AttentionPriorChannel) is the documented no-op.
+
+    Per plan §3.2 the substrate scores 7/8 typed + 1/8 no-op. The
+    Canal 4 absence is allowed by framework-C §6.2 provided the
+    no-op is explicitly documented. We assert here that the
+    adapter does NOT advertise an attention prior in its
+    ``execute_profile`` return — this is the empirical witness of
+    the no-op contract.
+    """
+    adapter = MLXLatentDiffusionSubstrate()
+    out = adapter.execute_profile(_StubRequest())
+    assert "attention_prior" not in out
+    # And that the components map does not list one either.
+    comps = adapter.components()
+    assert "attention_prior" not in comps
+
+
+# ===== Condition 2 : axiom property tests =====
+
+
+def test_c2_dr0_budget_accountability_via_loss_history() -> None:
+    """DR-0 : every training step is accountable in the loss history.
+
+    The Trainer's ``fit`` MUST return a loss list of length
+    ``n_epochs * steps_per_epoch`` — one entry per executed DE
+    (interpreted as one training step). This is the substrate-side
+    translation of DR-0 (every DE logged).
+    """
+    mx.random.seed(0)
+    denoiser = MLPDenoiser(d_latent=4, d_hidden=8, n_layers=2)
+    schedule = NoiseSchedule(t_steps=20, beta_min=1e-4, beta_max=2e-2)
+    trainer = Trainer(model=denoiser, schedule=schedule)
+    root = mx.random.key(7)
+    data_keys = mx.random.split(root, num=3)
+    dataset = [
+        mx.random.normal(shape=(2, 4), key=k) for k in data_keys
+    ]
+    history = trainer.fit(dataset=dataset, n_epochs=2, seed_key=root)
+    losses = history["loss"]
+    assert len(losses) == 2 * 3  # n_epochs * steps_per_epoch
+    for loss in losses:
+        assert math.isfinite(loss)
+
+
+def test_c2_dr2_prime_deterministic_canonical_order() -> None:
+    """DR-2' : repeated execution under the same canonical order
+    yields the same trace (loss list).
+
+    This is the substrate-side translation of DR-2' (strict
+    canonical-order determinism) : two independent runs with
+    identical seeds + identical dataset produce the same
+    loss-list-shaped trace.
+    """
+    def _run() -> list[float]:
+        mx.random.seed(0)
+        denoiser = MLPDenoiser(d_latent=4, d_hidden=8, n_layers=2)
+        schedule = NoiseSchedule(t_steps=20, beta_min=1e-4, beta_max=2e-2)
+        trainer = Trainer(model=denoiser, schedule=schedule)
+        root = mx.random.key(7)
+        data_keys = mx.random.split(root, num=2)
+        dataset = [
+            mx.random.normal(shape=(2, 4), key=k) for k in data_keys
+        ]
+        return trainer.fit(dataset=dataset, n_epochs=1, seed_key=root)["loss"]
+
+    a = _run()
+    b = _run()
+    assert a == b
+
+
+# ===== Condition 3 : BLOCKING invariants enforceable =====
+
+
+def test_c3_s2_finite_guard_on_sampler_output() -> None:
+    """S2 invariant : the sampler output must be finite.
+
+    Mirrors the S2 finite check used across the sibling substrates
+    (cf. ``test_dr3_micro_kiki_substrate.py::test_c3_s2_finite_*``).
+    """
+    import numpy as np
+
+    mx.random.seed(0)
+    denoiser = MLPDenoiser(d_latent=4, d_hidden=8, n_layers=2)
+    schedule = NoiseSchedule(t_steps=10, beta_min=1e-4, beta_max=2e-2)
+    sampler = Sampler(model=denoiser, schedule=schedule)
+    out = sampler.sample(key=mx.random.key(0), n_steps=4, shape=(2, 4))
+    arr = np.asarray(out)
+    assert np.all(np.isfinite(arr)), "S2 violated : sampler output non-finite"
+
+
+def test_c3_encoder_train_step_returns_finite_loss() -> None:
+    """S2 invariant : encoder train_step loss must be finite."""
+    mx.random.seed(0)
+    enc = Encoder(d_in=8, d_latent=4)
+    x = mx.random.normal(shape=(3, 8), key=mx.random.key(0))
+    loss = enc.train_step(x, lr=1e-3)
+    assert math.isfinite(loss), "S2 violated : encoder train_step non-finite"
+    assert loss >= 0.0

--- a/tests/reproducibility/golden_hashes_apple_m1_max.json
+++ b/tests/reproducibility/golden_hashes_apple_m1_max.json
@@ -33,5 +33,26 @@
     "hash": "1adfe6b3924fc33af3b1f07db8aaa60b4a2b41b891fee717650e8370d99b6b83",
     "mlx_version": "0.31.1",
     "status": "pending_review"
+  },
+  "test_r1_diffusion_train": {
+    "chip_family": "apple_m1_max",
+    "commit": "pending",
+    "hash": "pending",
+    "mlx_version": "pending",
+    "status": "pending_remote_validation"
+  },
+  "test_r1_diffusion_sample": {
+    "chip_family": "apple_m1_max",
+    "commit": "pending",
+    "hash": "pending",
+    "mlx_version": "pending",
+    "status": "pending_remote_validation"
+  },
+  "test_r1_diffusion_full_pipeline": {
+    "chip_family": "apple_m1_max",
+    "commit": "pending",
+    "hash": "pending",
+    "mlx_version": "pending",
+    "status": "pending_remote_validation"
   }
 }

--- a/tests/reproducibility/golden_hashes_apple_m5.json
+++ b/tests/reproducibility/golden_hashes_apple_m5.json
@@ -1,35 +1,56 @@
 {
+  "test_r1_diffusion_full_pipeline": {
+    "chip_family": "apple_m5",
+    "commit": "133315dcf72c",
+    "hash": "b4716f4083e1cbd993594a787d3b4e50879660419e7805aabcdc4f9787c92e78",
+    "mlx_version": "0.31.1",
+    "status": "pending_review"
+  },
+  "test_r1_diffusion_sample": {
+    "chip_family": "apple_m5",
+    "commit": "133315dcf72c",
+    "hash": "6f3fef19e4f0cd81bbc4eef567187c56946a3302eb307c6333e326d6786e6421",
+    "mlx_version": "0.31.1",
+    "status": "pending_review"
+  },
+  "test_r1_diffusion_train": {
+    "chip_family": "apple_m5",
+    "commit": "133315dcf72c",
+    "hash": "2399d97f07fa92d6f8a9bc079f022b6da8229bf68a2176939b8946e5e3cc74dc",
+    "mlx_version": "0.31.1",
+    "status": "pending_review"
+  },
   "test_r1_downscale": {
     "chip_family": "apple_m5",
-    "commit": "ce8facd760ce",
+    "commit": "133315dcf72c",
     "hash": "81297292f562ba9d9378e068e313071e54e129b50e0a4830ad2a9825813b9e28",
     "mlx_version": "0.31.1",
     "status": "pending_review"
   },
   "test_r1_full_pipeline": {
     "chip_family": "apple_m5",
-    "commit": "ce8facd760ce",
+    "commit": "133315dcf72c",
     "hash": "ba105f1432028d70b74441de8405a7fb50f30586787287626b5d973332c776c3",
     "mlx_version": "0.31.1",
     "status": "pending_review"
   },
   "test_r1_recombine": {
     "chip_family": "apple_m5",
-    "commit": "ce8facd760ce",
+    "commit": "133315dcf72c",
     "hash": "2f947c43b3abc5da51e3d7d3d6931f6ebbde9a1659e5b05c562d0e82e9b2c3f3",
     "mlx_version": "0.31.1",
     "status": "pending_review"
   },
   "test_r1_replay": {
     "chip_family": "apple_m5",
-    "commit": "ce8facd760ce",
+    "commit": "133315dcf72c",
     "hash": "37e1a4b47dfbc40df1b0b2921234ce546ebb5f32e1382a27730b59b9761c02c6",
     "mlx_version": "0.31.1",
     "status": "pending_review"
   },
   "test_r1_restructure": {
     "chip_family": "apple_m5",
-    "commit": "ce8facd760ce",
+    "commit": "133315dcf72c",
     "hash": "1adfe6b3924fc33af3b1f07db8aaa60b4a2b41b891fee717650e8370d99b6b83",
     "mlx_version": "0.31.1",
     "status": "pending_review"

--- a/tests/reproducibility/test_r1_diffusion.py
+++ b/tests/reproducibility/test_r1_diffusion.py
@@ -1,0 +1,196 @@
+"""R1 bit-exact reproducibility — MLX latent-diffusion substrate (M3).
+
+Adds three R1 entries per plan §2.3 D3 + §4 M3 :
+
+* ``test_r1_diffusion_train`` — hashes the per-step loss history of
+  a fixed-seed training run.
+* ``test_r1_diffusion_sample`` — hashes the sampler output of a
+  fixed-seed reverse-process draw against a deterministically-
+  initialized denoiser.
+* ``test_r1_diffusion_full_pipeline`` — hashes the end-to-end
+  encoder-train → denoiser-train → sample trace, with all three
+  building blocks seeded from a single root key (split-derived,
+  per the R1 contract).
+
+Per the §2.3 D3 contract, every ``mx.random.normal`` consumer
+inside the substrate stack receives a ``mx.random.split``-derived
+sub-key, never a raw ``mx.random.key(seed)`` value — the
+cross-machine probe (2026-05-20) showed raw-key consumption
+diverges on M1 Max while split-derived keys reproduce.
+
+The golden hashes are captured locally per chip family via
+:func:`tests.reproducibility._r1_helpers.compare_or_bootstrap` (the
+existing pattern) and start with ``"status": "pending_review"`` ;
+promotion to ``"accepted"`` happens manually after user review
+(2026-05-10 N2 rebaseline discipline).
+"""
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from kiki_oniric.substrates._diffusion import (  # noqa: E402
+    Encoder,
+    MLPDenoiser,
+    NoiseSchedule,
+    Sampler,
+    Trainer,
+)
+from tests.reproducibility._r1_helpers import (  # noqa: E402
+    CANONICAL_SEED,
+    canonical_hash,
+    compare_or_bootstrap,
+    tensor_to_list,
+)
+
+
+# Canonical sub-scenario parameters for the diffusion R1 entries.
+# These are pinned constants — never reorder, never re-seed in-place.
+_D_LATENT = 4
+_D_HIDDEN = 8
+_N_LAYERS = 2
+_T_STEPS = 8
+_BETA_MIN = 1e-4
+_BETA_MAX = 2e-2
+_BATCH_SIZE = 2
+_N_BATCHES = 2
+_N_EPOCHS = 1
+_N_SAMPLE_STEPS = 4
+
+
+def _make_models() -> tuple[Encoder, MLPDenoiser, NoiseSchedule]:
+    """Build E / U / σ under the canonical MLX seed.
+
+    Seeding is process-wide via ``mx.random.seed`` BEFORE any
+    ``nn.Linear`` construction so the initial weights are
+    deterministic across runs on a fixed (mlx version, chip family).
+    """
+    mx.random.seed(CANONICAL_SEED)
+    encoder = Encoder(d_in=_D_LATENT, d_latent=_D_LATENT)
+    mx.random.seed(CANONICAL_SEED + 1)
+    denoiser = MLPDenoiser(
+        d_latent=_D_LATENT, d_hidden=_D_HIDDEN, n_layers=_N_LAYERS,
+    )
+    schedule = NoiseSchedule(
+        t_steps=_T_STEPS, beta_min=_BETA_MIN, beta_max=_BETA_MAX,
+    )
+    return encoder, denoiser, schedule
+
+
+def _model_param_payload(model: Any) -> Any:
+    """Serialize a nn.Module's parameters to a nested float list."""
+    from mlx.utils import tree_flatten
+    flat = cast(list[tuple[str, Any]], tree_flatten(model.parameters()))
+    return [(key, tensor_to_list(val)) for key, val in flat]
+
+
+def test_r1_diffusion_train() -> None:
+    """Hash the loss history of a fixed-seed training run."""
+    _, denoiser, schedule = _make_models()
+    trainer = Trainer(
+        model=denoiser, schedule=schedule, optimizer_kwargs={"lr": 1e-3},
+    )
+    root = mx.random.key(CANONICAL_SEED)
+    train_root, data_root = mx.random.split(root, num=2)
+    data_keys = mx.random.split(data_root, num=_N_BATCHES)
+    dataset = [
+        mx.random.normal(shape=(_BATCH_SIZE, _D_LATENT), key=k)
+        for k in data_keys
+    ]
+    losses = trainer.fit(
+        dataset=dataset, n_epochs=_N_EPOCHS, seed_key=train_root,
+    )["loss"]
+
+    payload = {
+        "op": "diffusion_train",
+        "losses": [float(loss) for loss in losses],
+        "final_params": _model_param_payload(denoiser),
+        "seed": CANONICAL_SEED,
+        "n_epochs": _N_EPOCHS,
+        "n_batches": _N_BATCHES,
+        "batch_size": _BATCH_SIZE,
+        "d_latent": _D_LATENT,
+        "t_steps": _T_STEPS,
+    }
+    digest = canonical_hash(payload)
+    compare_or_bootstrap("test_r1_diffusion_train", digest)
+
+
+def test_r1_diffusion_sample() -> None:
+    """Hash the sampler output of a fixed-seed reverse draw."""
+    _, denoiser, schedule = _make_models()
+    sampler = Sampler(model=denoiser, schedule=schedule)
+    root = mx.random.key(CANONICAL_SEED)
+    sample = sampler.sample(
+        key=root,
+        n_steps=_N_SAMPLE_STEPS,
+        shape=(_BATCH_SIZE, _D_LATENT),
+    )
+
+    payload = {
+        "op": "diffusion_sample",
+        "sample": tensor_to_list(sample),
+        "seed": CANONICAL_SEED,
+        "n_steps": _N_SAMPLE_STEPS,
+        "shape": [_BATCH_SIZE, _D_LATENT],
+        "t_steps": _T_STEPS,
+    }
+    digest = canonical_hash(payload)
+    compare_or_bootstrap("test_r1_diffusion_sample", digest)
+
+
+def test_r1_diffusion_full_pipeline() -> None:
+    """Hash the end-to-end encoder-train → denoiser-train → sample trace.
+
+    Single-DE pipeline mirroring the existing R1 full-pipeline
+    pattern (one DE through all the wired ops, final state
+    hashed).
+    """
+    encoder, denoiser, schedule = _make_models()
+    root = mx.random.key(CANONICAL_SEED)
+    enc_root, train_root, sample_root, data_root = mx.random.split(
+        root, num=4
+    )
+
+    # 1. One encoder train step on a fixed batch.
+    enc_batch_key = mx.random.split(enc_root, num=1)[0]
+    enc_batch = mx.random.normal(
+        shape=(_BATCH_SIZE, _D_LATENT), key=enc_batch_key,
+    )
+    enc_loss = encoder.train_step(enc_batch, lr=1e-3)
+
+    # 2. One denoiser fit pass on a small synthetic dataset.
+    trainer = Trainer(
+        model=denoiser, schedule=schedule, optimizer_kwargs={"lr": 1e-3},
+    )
+    data_keys = mx.random.split(data_root, num=_N_BATCHES)
+    dataset = [
+        mx.random.normal(shape=(_BATCH_SIZE, _D_LATENT), key=k)
+        for k in data_keys
+    ]
+    losses = trainer.fit(
+        dataset=dataset, n_epochs=_N_EPOCHS, seed_key=train_root,
+    )["loss"]
+
+    # 3. One reverse-process draw.
+    sampler = Sampler(model=denoiser, schedule=schedule)
+    sample = sampler.sample(
+        key=sample_root,
+        n_steps=_N_SAMPLE_STEPS,
+        shape=(_BATCH_SIZE, _D_LATENT),
+    )
+
+    payload = {
+        "op": "diffusion_full_pipeline",
+        "encoder_loss": float(enc_loss),
+        "denoiser_losses": [float(loss) for loss in losses],
+        "encoder_params": _model_param_payload(encoder),
+        "denoiser_params": _model_param_payload(denoiser),
+        "final_sample": tensor_to_list(sample),
+        "seed": CANONICAL_SEED,
+    }
+    digest = canonical_hash(payload)
+    compare_or_bootstrap("test_r1_diffusion_full_pipeline", digest)

--- a/tests/unit/test_diffusion_sampler_keys.py
+++ b/tests/unit/test_diffusion_sampler_keys.py
@@ -1,0 +1,111 @@
+"""R1 key-derivation contract for the diffusion :class:`Sampler`.
+
+Per plan §2.3 D3 + §4 M3, the sampler MUST consume only
+``mx.random.split``-derived keys (never raw ``mx.random.key(seed)``
+straight to ``mx.random.normal``) and produce a bit-identical
+output given a fixed ``(root_key, n_steps, shape)`` triple on a
+fixed MLX version + chip family.
+
+Tests :
+
+1. Deterministic given (root_key, n_steps, shape) — two runs
+   produce bit-identical arrays.
+2. Different root_key → different output.
+3. Key tree depth matches n_steps + 1 (no leakage).
+4. Shape invariance — output shape == requested shape.
+5. Skipped on platforms without MLX (Linux CI) via
+   :func:`pytest.importorskip`.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import mlx.core as mx
+else:
+    mx = pytest.importorskip("mlx.core")
+
+from kiki_oniric.substrates._diffusion import (
+    MLPDenoiser,
+    NoiseSchedule,
+    Sampler,
+)
+
+
+def _make_sampler(d_latent: int = 4, t_steps: int = 16) -> Sampler:
+    """Build a deterministic small sampler (real weights, fixed seed)."""
+    mx.random.seed(0)
+    denoiser = MLPDenoiser(d_latent=d_latent, d_hidden=8, n_layers=2)
+    schedule = NoiseSchedule(t_steps=t_steps, beta_min=1e-4, beta_max=2e-2)
+    return Sampler(model=denoiser, schedule=schedule)
+
+
+def _hash_array(arr: "mx.array") -> tuple[float, ...]:
+    """Return a flat tuple of floats for bit-exact equality assertions."""
+    import numpy as np
+
+    return tuple(np.asarray(arr).astype(float).flatten().tolist())
+
+
+def test_sampler_deterministic_given_same_root_key() -> None:
+    """Same root key + n_steps + shape ⇒ bit-identical output."""
+    sampler = _make_sampler()
+    key = mx.random.key(123)
+    out_a = sampler.sample(key=key, n_steps=4, shape=(2, 4))
+    out_b = sampler.sample(key=key, n_steps=4, shape=(2, 4))
+    assert _hash_array(out_a) == _hash_array(out_b)
+
+
+def test_sampler_different_root_key_yields_different_output() -> None:
+    """Flipping the root key produces a different sample.
+
+    Equality is bit-level on flattened floats ; with probability
+    ≈ 1 over a fresh standard normal draw at least one element
+    differs. We assert at least one element differs.
+    """
+    sampler = _make_sampler()
+    out_a = sampler.sample(key=mx.random.key(1), n_steps=4, shape=(2, 4))
+    out_b = sampler.sample(key=mx.random.key(2), n_steps=4, shape=(2, 4))
+    flat_a = _hash_array(out_a)
+    flat_b = _hash_array(out_b)
+    assert any(a != b for a, b in zip(flat_a, flat_b))
+
+
+def test_sampler_key_tree_depth_matches_n_steps_plus_one() -> None:
+    """The sampler derives exactly ``n_steps + 1`` subkeys.
+
+    We probe the contract by mirroring the documented key
+    derivation : ``mx.random.split(root, num=n_steps + 1)`` MUST
+    succeed and MUST yield the same first sub-key used for the
+    initial-noise draw across two independent splits.
+    """
+    n_steps = 5
+    root = mx.random.key(42)
+    subs_a = mx.random.split(root, num=n_steps + 1)
+    subs_b = mx.random.split(root, num=n_steps + 1)
+    # split must be deterministic on the same root key.
+    for i in range(n_steps + 1):
+        assert _hash_array(subs_a[i]) == _hash_array(subs_b[i])
+    # And shape[0] is exactly n_steps + 1.
+    assert subs_a.shape[0] == n_steps + 1
+
+
+def test_sampler_shape_invariance() -> None:
+    """Output shape matches the requested ``shape`` argument."""
+    sampler = _make_sampler(d_latent=8, t_steps=10)
+    for shape in [(1, 8), (3, 8), (4, 8)]:
+        out = sampler.sample(key=mx.random.key(7), n_steps=3, shape=shape)
+        assert tuple(out.shape) == shape
+
+
+def test_sampler_rejects_invalid_n_steps_or_shape() -> None:
+    """Defensive guards : n_steps must be in (0, schedule.t_steps]."""
+    sampler = _make_sampler(d_latent=4, t_steps=8)
+    with pytest.raises(ValueError, match="n_steps"):
+        sampler.sample(key=mx.random.key(0), n_steps=0, shape=(1, 4))
+    with pytest.raises(ValueError, match="exceeds schedule"):
+        sampler.sample(key=mx.random.key(0), n_steps=99, shape=(1, 4))
+    with pytest.raises(ValueError, match="shape must be non-empty"):
+        sampler.sample(key=mx.random.key(0), n_steps=2, shape=())

--- a/tests/unit/test_mlx_latent_diffusion_adapter.py
+++ b/tests/unit/test_mlx_latent_diffusion_adapter.py
@@ -209,28 +209,62 @@ def test_forward_passes_return_correct_shapes() -> None:
 # ----------------------------------------------------------------------
 
 
-def test_skeleton_methods_raise_not_implemented_where_deferred() -> None:
-    """Documented M3+ deferrals surface as ``NotImplementedError``.
+def test_execute_profile_runs_minimal_smoke_cycle() -> None:
+    """Wave 3b M3 wires a minimal train + sample driver.
 
-    This pins the public contract: callers must not silently get
-    placeholder numbers from training or from
-    ``execute_profile`` until the M3 trainer and ablation_cycle3
-    wiring land.
+    The smoke cycle returns the standard metrics-dict shape used
+    by the sibling substrates and carries a ``"synthetic": True``
+    flag per CLAUDE.md §Working rules item 3 (no synthetic
+    placeholder may be reported as an empirical claim).
     """
-    adapter = MLXLatentDiffusionSubstrate()
+    from dataclasses import dataclass
 
-    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
-        adapter.execute_profile(request=None)
+    @dataclass
+    class _StubRequest:
+        seed: int = 7
+        profile: str = "p_min"
+
+    adapter = MLXLatentDiffusionSubstrate()
+    out = adapter.execute_profile(_StubRequest())
+
+    # Standard sibling-substrate keys.
+    for key in (
+        "replay_rate", "downscale_norm", "restructure_sum",
+        "recombine_rate", "delta_acc", "wall_time_s",
+    ):
+        assert key in out, f"missing metric key {key!r}"
+        assert isinstance(out[key], float), f"{key!r} must be float"
+
+    # M3-specific provenance keys (honesty marker + identity).
+    assert out["synthetic"] is True
+    assert out["profile"] == "p_min"
+    assert out["seed"] == 7
+    assert out["substrate"] == "mlx_latent_diffusion"
+    assert isinstance(out["substrate_version"], str)
+    assert out["substrate_version"].startswith("C-v")
+    assert out["substrate_version"].endswith("+PARTIAL")
+
+    # teardown is a real no-op : it must be callable without raising.
+    adapter.teardown()
+
+
+def test_encoder_and_denoiser_train_step_smoke() -> None:
+    """``train_step`` runs without raising and returns a finite loss."""
+    import math
 
     enc = Encoder(d_in=4, d_latent=2)
-    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
-        enc.train_step()
+    x = mx.zeros((3, 4), dtype=mx.float32)
+    loss = enc.train_step(x, lr=1e-3)
+    assert isinstance(loss, float)
+    assert math.isfinite(loss)
+    assert loss >= 0.0
 
+    schedule = NoiseSchedule(t_steps=10, beta_min=1e-4, beta_max=2e-2)
     denoiser = MLPDenoiser(d_latent=2, d_hidden=4, n_layers=1)
-    with pytest.raises(NotImplementedError, match="Wave 3b M3"):
-        denoiser.train_step()
-
-    # teardown is a real no-op in M2 (not deferred): it must be callable
-    # without raising. The return annotation is ``-> None`` so we just
-    # invoke it; mypy disallows asserting on a None-returning callable.
-    adapter.teardown()
+    z = mx.zeros((3, 2), dtype=mx.float32)
+    t = mx.array([0, 1, 2], dtype=mx.int32)
+    noise = mx.zeros((3, 2), dtype=mx.float32)
+    loss_d = denoiser.train_step(z, t, noise, schedule, lr=1e-3)
+    assert isinstance(loss_d, float)
+    assert math.isfinite(loss_d)
+    assert loss_d >= 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -248,7 +248,7 @@ wheels = [
 
 [[package]]
 name = "dreamofkiki"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Wave 3b M3 — train + sample + R1 golden (Track S)

Per plan §4 M3 + §3.1 + §3.4. Track S selected at M2 review : full DR-3 conformance test family + 3 R1 entries.

### What's in

**New code**
- `kiki_oniric/substrates/_diffusion/sampler.py` (~160 LoC) — DDPM reverse-process sampler with the R1-clean per-step subkey tree (plan §2.3 D3 : `mx.random.split(root_key, num=n_steps+1)`, no raw-key consumption by `mx.random.normal`).
- `kiki_oniric/substrates/_diffusion/trainer.py` (~150 LoC) — noise-prediction SGD `Trainer.fit` / `train_step`, deterministic given `(dataset, n_epochs, seed_key, MLX version, chip family)`.

**Model upgrade**
- `kiki_oniric/substrates/_diffusion/model.py` — `Encoder` and `MLPDenoiser` upgraded to `nn.Module` with learnable parameters and a real `train_step` (MSE reconstruction / noise-prediction). M2 NotImplementedError surface removed ; public `__call__` shape contract preserved.

**Adapter wiring**
- `kiki_oniric/substrates/mlx_latent_diffusion.py` — `execute_profile` now runs a deterministic synthetic-latent smoke cycle (`Trainer.fit` + `Sampler.sample`) and returns a sibling-shaped metrics dict with a `"synthetic": True` honesty marker per CLAUDE.md §Working rules item 3. The CIFAR-100 loader + ablation_cycle3 wiring lands in M4.

**Tests (3 conformance families + R1 + unit)**
| File | Family | Tests |
|------|--------|-------|
| `tests/unit/test_diffusion_sampler_keys.py` | R1 key-derivation contract | 5 |
| `tests/conformance/axioms/test_dr3_diffusion_substrate.py` | DR-3 conditions 1/2/3 (7/8 typed + Canal 4 no-op) | 8 |
| `tests/conformance/axioms/test_dr0_diffusion_de_budget.py` | DR-0 accountability (Hypothesis) | 4 |
| `tests/conformance/axioms/test_dr1_diffusion_finite.py` | DR-1 finiteness | 4 |
| `tests/reproducibility/test_r1_diffusion.py` | 3 R1 entries (train / sample / full_pipeline) | 3 |
| `tests/unit/test_mlx_latent_diffusion_adapter.py` | Adapter Protocol + smoke (extended) | +2 / -1 |

**33 new tests, all green locally on M5.**

### DualVer bump (atomic)

- Substrate-internal `mlx_latent_diffusion` : `C-v0.13.0+PARTIAL` → `C-v0.14.0+PARTIAL` (M2 set 0.13.0 prematurely ; M3 closes the substrate-internal MINOR).
- Framework axis CHANGELOG entry : `[C-v0.24.0+PARTIAL]` (one MINOR bump per substantive PR, matching the recent B6 series).
- `pyproject.toml` : `0.21.0` → `0.22.0`.
- EC stays **PARTIAL**. M6 will conditionally flip to STABLE per framework-C §12.3 — not this PR.

### R1 golden status

- **apple_m5** : 3 hashes captured locally, `status: "pending_review"` per the 2026-05-10 N2 rebaseline discipline. Promotion to `"accepted"` is a separate manual step.
  - `test_r1_diffusion_train` → `2399d97f07fa92d6f8a9bc079f022b6da8229bf68a2176939b8946e5e3cc74dc`
  - `test_r1_diffusion_sample` → `6f3fef19e4f0cd81bbc4eef567187c56946a3302eb307c6333e326d6786e6421`
  - `test_r1_diffusion_full_pipeline` → `b4716f4083e1cbd993594a787d3b4e50879660419e7805aabcdc4f9787c92e78`
- **apple_m1_max** : 3 placeholders with `status: "pending_remote_validation"` — will bootstrap on the next macM1 run via `compare_or_bootstrap`'s unknown-status path. Cross-machine R1 expected to PARTIALLY fail on M1 Max per the issue #3568 known limitation (plan §4 M3 acceptance) — document, do not block.

### Coverage on new modules

| Module | Coverage |
|--------|----------|
| `_diffusion/__init__.py` | 100% |
| `_diffusion/sampler.py` | 97% |
| `_diffusion/trainer.py` | 93% |
| `_diffusion/model.py` | 96% |
| `mlx_latent_diffusion.py` | 98% |

All ≥ 90 % per plan §3.4 acceptance.

### Out of scope

- M4 : `ablation_cycle3_diffusion.py` + CIFAR-100 loader + smoke run.
- M6 : Paper 2 §7.9 + DualVer STABLE flip.
- OSF amendment send (waits M3 landing + PI approver).

Dated immutables under `docs/plans/`, `docs/osf-*` are deliberately untouched per `docs/CLAUDE.md` append-only rule.

### Local verification

```
ruff check kiki_oniric tests scripts            : clean
mypy kiki_oniric                                : 180 errors (= baseline, 0 new)
mypy harness tests                              : 0 errors
pytest (full suite)                             : 898 passed, 3 skipped, 12 xfailed, 0 failed
pytest (new tests)                              : 33 passed
```

Critic verdict requested before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
