### PR TITLE
docs: Wave 3b M6 + M7 specs (M7 first)

### DIFF
--- a/docs/superpowers/specs/2026-05-21-m6-m7-sequencing.md
+++ b/docs/superpowers/specs/2026-05-21-m6-m7-sequencing.md
@@ -1,0 +1,108 @@
+# M6 + M7 sequencing decision
+
+> **Context** : Wave 3b M5 shipped 2026-05-21 (PR #35, squash `ffe0aeb`)
+> with a known DR-3 gap : `mlx_latent_diffusion.execute_profile` does
+> not branch on `request.profile`. Issue [#36](https://github.com/hypneum-lab/dream-of-kiki/issues/36).
+> Two milestones are open : M6 (paper §7.9 + OSF amendment + DualVer
+> decision + ship-critic) and M7 (the substrate fix for #36).
+>
+> **Decision** : run **M7 first, then M6**.
+
+## 1. Why M7 first
+
+The OSF amendment Q6JYN-W3B carries a permanent DataCite DOI once
+filed. The principle from `docs/CLAUDE.md` "Dated immutables" is :
+*don't ship a primary record you'll have to amend again next week*.
+
+Three concrete arguments :
+
+1. **Paper §7.9 evidence quality.** Drafting §7.9 against the M5
+   v2 milestone means writing "the substrate is non-discriminative
+   under an EC intensity proxy" as the headline empirical claim. A
+   reader of the published Wave 3b paper would treat that as the
+   *real* result of the framework's diffusion substrate. We don't
+   want that to be the public-record result if 3-5 days of substrate
+   work yields a discriminative one.
+2. **DualVer flip economics.** M6's STABLE/PARTIAL decision is
+   gated by §12.3 of the framework-C spec, which requires
+   conformance pass + axiom no-violation + ship-critic GO. Issue
+   #36 is a DR-3 conformance gap — STABLE is impossible while it
+   stays open. M6-first would force a `+PARTIAL` flip, then M7
+   would force *another* DualVer bump (FC PATCH or MINOR) to flip
+   to STABLE. Two flips means two CHANGELOG amendments, two
+   `STATUS.md` "Prior :" prepends, and a 24-hour window where the
+   public version disagrees with the substrate state.
+3. **Ship-critic precedent.** `feedback_critic_before_ship.md`
+   records 4 prior cases where the critic-before-ship gate caught
+   a paper-rejection-grade issue. A critic-reviewed M6 with #36
+   open would almost certainly flag the gap as a *spec contract
+   not honoured* — and ask us to fix it before shipping. Doing M7
+   first front-loads that fix.
+
+## 2. What M6-first would cost
+
+If we did M6 first as `+PARTIAL` :
+
+- The OSF amendment filing is the only step with permanence cost.
+  If the amendment text says "future work : substrate profile
+  differentiation", that's defensible — but it weakens the Wave 3b
+  claim and reads as a hedged result. A reader citing the DOI gets
+  the hedged version forever.
+- ~4 hours saved (no need to re-run the bench; the M5 v2 milestone
+  is the cited evidence).
+- M7 then ships as a follow-up amendment (Q6JYN-W3B-v2) or as a
+  separate OSF record entirely.
+
+The 4 hours saved aren't worth the permanent-record cost.
+
+## 3. What M7-first costs
+
+- 3-5 days substrate work (issue #36 fix : wire the 4 dream-side
+  primitives through `execute_profile` per profile activation,
+  surface real per-op metrics, FC MINOR bump).
+- A re-run of the 450-cell bench on macM1 (~30 min wall).
+- A new milestone `docs/milestones/wave3b-bench-2026-05-2X.{json,md,cells.jsonl}`
+  (date pinned at re-run).
+- The old `wave3b-bench-2026-05-21.{json,md,cells.jsonl}` stays
+  in `docs/milestones/` as the dated immutable record (it documents
+  the M5+quick-win state and was the formal evidence for issue #36).
+
+## 4. Recovery posture
+
+If M7 stalls past day 5 :
+
+- Fall back to **M6 as `+PARTIAL`** using the existing 2026-05-21
+  milestone. Paper §7.9 then explicitly frames the result as
+  "harness shipped, profile-discrimination deferred to follow-up
+  Wave 3c sub-cycle".
+- File the OSF amendment with the hedged language.
+- M7 becomes its own milestone (M7 → Wave 3c first deliverable).
+
+This recovery is a safety valve, not the plan.
+
+## 5. Sequence
+
+```
+M7 spec      → 2026-05-21-m7-substrate-dr3-design.md   (this PR)
+M7 plan      → docs/superpowers/plans/2026-05-2X-m7-substrate-dr3.md
+M7 implement → branch feat/m7-substrate-dr3, ~3-5 days, FC MINOR
+M7 re-bench  → macM1, 30 min wall, new dated milestone
+M6 spec      → 2026-05-21-m6-paper-osf-design.md       (this PR)
+M6 plan      → docs/superpowers/plans/2026-05-2X-m6-paper-osf.md
+M6 implement → paper §7.9 EN + FR + DR-3 evidence v1.0
+              + ship-critic + OSF amendment + DualVer flip
+```
+
+Both M7 and M6 specs ship in this same PR so the user can review
+the plan as a coherent whole before any code lands.
+
+## 6. Self-review
+
+- **Placeholder scan** : no TBD ; the dated path on the M7 re-bench
+  is intentionally `2026-05-2X` (resolved at re-bench time).
+- **Internal consistency** : the M7-first sequence is consistent
+  across §1, §3, §5 ; the recovery posture §4 explicitly handles
+  the stall case.
+- **Scope check** : this decision doc is a *sequencing* spec — one
+  decision, one rationale, one fallback. Two companion specs cover
+  the actual deliverables. Fits the brainstorming-skill split.

--- a/docs/superpowers/specs/2026-05-21-m6-paper-osf-design.md
+++ b/docs/superpowers/specs/2026-05-21-m6-paper-osf-design.md
@@ -1,0 +1,195 @@
+# M6 — Paper 2 §7.9 + DR-3 evidence v1.0 + OSF amendment design
+
+> **Parent decision** : `2026-05-21-m6-m7-sequencing.md` — M6 runs
+> *after* M7. The cited bench is the post-M7 v3 dump
+> (`docs/milestones/wave3b-bench-2026-05-2X.{json,md,cells.jsonl}`),
+> not the M5 v2 dump from 2026-05-21.
+> **DualVer** : ship-critic-gated flip from `C-v0.15.0+PARTIAL`
+> (post-M7) to `+STABLE` iff framework-C §12.3 holds. Otherwise stay
+> `+PARTIAL` and document the deferred cell.
+
+## 1. Goal
+
+Close Wave 3b by producing the public-record artefacts :
+
+- **`docs/papers/paper2/results.md` §7.9** : a new section drafting
+  the Wave 3b latent-diffusion-substrate empirical story end-to-end,
+  citing the post-M7 bench.
+- **FR mirror** `docs/papers/paper2-fr/results.md` §7.9 (EN→FR rule
+  per `CONTRIBUTING.md`).
+- **`docs/proofs/dr3-diffusion-substrate-evidence.md` v1.0** : the
+  behavioural-angle proof now backed by the M7 conformance test +
+  the bench-v3 numbers, replacing the v0.1 PARTIAL stub.
+- **OSF amendment Q6JYN-W3B** published with a DataCite DOI.
+- **CHANGELOG** entry for the final DualVer state (STABLE if §12.3
+  holds, else PARTIAL with the deferred-cell justification).
+- **Ship-critic review** verdict GO before any of the above lands
+  on `main`.
+
+## 2. Decisions
+
+### D1 — Bench cited
+
+The Wave 3b paper §7.9 cites **the post-M7 bench v3**, not the
+2026-05-21 M5+quick-win bench. The 2026-05-21 milestone stays in
+`docs/milestones/` as the **dated immutable record** of the
+intermediate state (the EC quick-win documented the substrate gap
+formally and motivated M7) and is referenced once in §7.9 as the
+audit trail for issue #36 — but the **headline numbers** are the
+v3 numbers.
+
+### D2 — DualVer flip gating
+
+`framework-C §12.3` STABLE conditions :
+
+1. All conformance tests pass on the latest commit.
+2. No axiom violation in the test matrix.
+3. Ship-critic GO verdict on the M6 PR.
+4. At least one positive empirical claim of the substrate's
+   profile-discrimination capability is registered in the bench.
+
+If all four hold post-M7 bench v3, M6 flips to `+STABLE` (FC PATCH
+`C-v0.15.0 → C-v0.15.1+STABLE`). Otherwise it stays
+`C-v0.15.0+PARTIAL`, the CHANGELOG records the failing condition
+explicitly, and §7.9 frames the result accordingly.
+
+The acceptance test is **mechanical** : the M6 plan ships a CI
+check `scripts/check_§12_3_stable_conditions.py` (or similar) that
+returns a boolean. The bump is the boolean.
+
+### D3 — Paper §7.9 structure
+
+The §7.9 EN draft has 5 sub-sections, each capped at ~250-400
+words :
+
+- **§7.9.1 Substrate description.** Recap the diffusion substrate
+  (Encoder + MLPDenoiser + NoiseSchedule + Trainer + Sampler), cite
+  the M2 skeleton + M3 wiring + M5 harness + M7 profile binding
+  milestones with their commits.
+- **§7.9.2 Conformance posture.** State 8/8 typed primitives with
+  Canal 4 documented no-op (cite v0.1 evidence) ; cite the M7
+  conformance test asserting the profile-activation surface.
+- **§7.9.3 Empirical setup.** N=30 seeds × 5 CIFAR-100 task-splits
+  × 3 profiles, 450 cells on macM1 (cite the bench v3 milestone +
+  the R1 reproducibility hashes).
+- **§7.9.4 Headline result.** Whichever pattern bench v3 produced :
+  positive H1/H2/H4 (point to the rejected null), or empty
+  (extend the DR-4 v0.6 amendment's empirical-emptiness scope to
+  the diffusion substrate, mirror the G4-sexto / -septimo paragraph
+  style). The §7.9.4 *template* is drafted before bench v3 runs ;
+  the *fill-in* happens after.
+- **§7.9.5 Audit trail.** Briefly note the M5 → quick-win → issue
+  #36 → M7 sequence, cite the 2026-05-21 milestone as the
+  documented intermediate state, and link the OSF amendment.
+
+EN draft ships, FR mirror follows in the same PR.
+
+### D4 — DR-3 evidence v1.0
+
+Replace `docs/proofs/dr3-diffusion-substrate-evidence.md` v0.1
+PARTIAL with v1.0 :
+
+- 8/8 primitives typed (the 7 + Canal 4 doc-no-op posture from
+  v0.1 is preserved ; M7 adds the formal profile-activation
+  surface as the missing piece).
+- Cite the new `tests/conformance/axioms/test_dr3_diffusion_profile.py`
+  as the conformance proof.
+- Cite the bench v3 milestone as the behavioural-angle evidence.
+- Status block flips to `v1.0 STABLE` iff D2's 4 conditions hold,
+  else stays `v1.0 PARTIAL` with the same deferred-cell note.
+
+### D5 — OSF amendment
+
+The amendment text in `docs/osf-amendment-wave3b.md` (already drafted
+2026-04-19, never filed) is updated to cite the final substrate
+posture + bench-v3 evidence. Then filed against Q6JYN with a
+DataCite DOI. Key changes from the 2026-04-19 draft :
+
+- The R1 entries section updates with the **regenerated** golden
+  hashes (M7 FC MINOR bump changed them ; the original draft cited
+  pending-review hashes that no longer exist).
+- The "Cross-machine R1" caveat references the MLX #3568 issue
+  (M1 Max divergence) — already documented in the prior milestone.
+- The "DualVer transition" line states the final state (STABLE or
+  PARTIAL per D2).
+
+Filing is the user's action (OSF web UI). M6 ships the text ready
+to copy-paste ; the DOI is recorded in the CHANGELOG after filing.
+
+### D6 — Ship-critic invocation
+
+Per `feedback_critic_before_ship.md` (4 prior validations), the
+critic-before-ship gate is mandatory. The critic-reviewer subagent
+is dispatched with the full M6 PR diff in fresh context, scoped to :
+
+- Does §7.9 match the bench v3 numbers exactly ?
+- Does the DR-3 evidence v1.0 cite real, registered conformance
+  tests ?
+- Does the OSF amendment text match the actual repo state ?
+- Does the DualVer flip honour §12.3 ?
+- Are EN and FR mirrors consistent ?
+
+If the critic finds a *blocking* issue, fix it and re-dispatch.
+Treat the verdict as binding.
+
+### D7 — Acceptance
+
+M6 ships when :
+
+1. EN §7.9 + FR §7.9 mirror both committed and reviewed.
+2. DR-3 evidence v1.0 committed.
+3. DualVer bump committed (STABLE or PARTIAL per D2) ;
+   `CHANGELOG.md` updated ; `STATUS.md` "Prior :" prepended.
+4. OSF amendment text finalised in `docs/osf-amendment-wave3b.md`,
+   filing instructions handed to the user.
+5. Ship-critic verdict = GO (or all blocking findings fixed and
+   re-reviewed GO).
+6. Full test suite green, ruff + mypy clean, coverage gate satisfied.
+
+## 3. File touch map (M6 implementation plan target)
+
+| File | Action | LoC est. |
+|---|---|---|
+| `docs/papers/paper2/results.md` | Add §7.9 (5 sub-sections, ~1500 words) | +250 |
+| `docs/papers/paper2-fr/results.md` | FR mirror of §7.9 | +250 |
+| `docs/proofs/dr3-diffusion-substrate-evidence.md` | Bump v0.1 → v1.0 | +60 −10 |
+| `docs/osf-amendment-wave3b.md` | Finalise for filing | +30 |
+| `CHANGELOG.md` | New section `[C-v0.15.1+STABLE]` or `[C-v0.15.0+PARTIAL]` (final) | +20 |
+| `STATUS.md` | Prepend M6 closure entry | +1 (one long line) |
+| `pyproject.toml` | SemVer bump (PATCH if STABLE flip, no-op if PARTIAL stays) | ±1 |
+| `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §12.3 | Cite the new STABLE-condition check script (or fix an inconsistency surfaced by the critic) | +5..20 |
+| `scripts/check_dualver_stable.py` | New : mechanical check returning bool for D2 | +60 |
+
+EN→FR rule applies to any §12 spec edit.
+
+## 4. Out of scope for M6
+
+- Re-running the bench (that is M7's deliverable).
+- New substrates (M6 ships *one* substrate's paper section).
+- Cross-paper writing (`papers/byline-policy.md` etc.) — separate
+  hygiene PR if needed.
+- Wave 3c planning — separate spec.
+
+## 5. Risks
+
+| Ref | Risk | Mitigation |
+|---|---|---|
+| R1 | Bench v3 produces empty H1/H2/H4 → STABLE blocked | §7.9.4 template handles both branches ; OSF amendment is filed with PARTIAL framing if needed. M6 still ships. |
+| R2 | Ship-critic finds a *blocking* issue (e.g. §7.9 number mismatch with the actual JSON) | Fix and re-dispatch ; precedent from the 4 prior cases shows this adds ~2 hours per cycle. |
+| R3 | The OSF amendment text references commits / tags that haven't yet been pushed | The plan ships the amendment AFTER the M6 PR merges, so the cited SHAs are stable. |
+| R4 | FR mirror drift (EN updated, FR stale) | The CONTRIBUTING.md rule blocks the PR ; the plan ships EN and FR in the same commit. |
+
+## 6. Self-review
+
+- **Placeholder scan** : no TBD ; "STABLE *or* PARTIAL" branches are
+  intentional, with mechanical resolution (D2).
+- **Internal consistency** : D1 (cite v3 bench) ↔ D3 (§7.9.4 cites
+  v3 numbers) ↔ D5 (amendment cites regenerated R1) all reference
+  the post-M7 state.
+- **Scope check** : single milestone, single paper section, single
+  amendment. Fits one writing-plans plan ; the ship-critic step is
+  one task within that plan, not a separate spec.
+- **Ambiguity** : §7.9.4 template-then-fill is acknowledged. The
+  plan task drafting §7.9 starts with the template (executable
+  before bench v3 finishes) and a second task fills in the numbers
+  (sequenced after bench v3 lands).

--- a/docs/superpowers/specs/2026-05-21-m7-substrate-dr3-design.md
+++ b/docs/superpowers/specs/2026-05-21-m7-substrate-dr3-design.md
@@ -1,0 +1,185 @@
+# M7 — Substrate DR-3 conformance fix design
+
+> **Closes** : issue [#36](https://github.com/hypneum-lab/dream-of-kiki/issues/36).
+> **Parent decision** : `2026-05-21-m6-m7-sequencing.md` — M7 first.
+> **DualVer impact** : FC MINOR `C-v0.14.0 → C-v0.15.0`, EC stays `+PARTIAL`
+> until the post-M7 bench v3 + ship-critic.
+
+## 1. Goal
+
+Make `kiki_oniric/substrates/mlx_latent_diffusion.execute_profile`
+honour the framework-C profile contract : each profile activates a
+*distinct subset* of the 4 dream-side primitives, and each activated
+primitive emits its own **real** per-op metric (not a proxy of the
+denoiser loss).
+
+After M7, the 450-cell ablation bench produces *non-trivial* H1 / H2 /
+H4 verdicts — `reject_h0 == True` exactly where the framework predicts,
+and `False` exactly where it predicts the empirical-emptiness pattern
+(DR-4 v0.6 amendment, paper 2 §6).
+
+## 2. The contract (framework C §3, kiki_oniric/profiles/)
+
+The three profiles activate the dream-side primitives as follows
+(verbatim from `kiki_oniric/profiles/p_min.py`, `p_equ.py`,
+`p_max.py` — confirm against disk at plan time) :
+
+| Profile | Replay (α) | Downscale (β) | Restructure (γ) | Recombine (δ) |
+|---|---|---|---|---|
+| `p_min` | — | — | — | ✓ |
+| `p_equ` | ✓ | ✓ | — | ✓ |
+| `p_max` | ✓ | ✓ | ✓ | ✓ |
+
+(Mapping is illustrative — M7 plan reads the real profile dataclasses
+from `kiki_oniric/profiles/` and binds the substrate to them ; if the
+disk shape diverges from this table, the disk wins.)
+
+`mlx_latent_diffusion` today runs `Trainer(denoiser).fit + Sampler.sample`
+unconditionally and attaches the profile string to the output dict. M7
+replaces this with a per-profile pipeline that calls the real handler
+for each activated primitive.
+
+## 3. Decisions
+
+### D1 — Handler boundary
+
+- **Reuse** the existing `_real.py` handlers in
+  `kiki_oniric/dream/operations/{replay,downscale,restructure,recombine}_real.py`.
+  They already implement the K1 FLOP-tag contract and the S2 / S3
+  guards. Do **not** inline op logic into `mlx_latent_diffusion`.
+- The substrate gives each handler the diffusion-substrate-specific
+  state object it needs (a small adapter dataclass holding the
+  denoiser / encoder / sampler handles), and reads back the
+  state's emitted metric.
+
+### D2 — Per-op metrics
+
+Replace the M5-era proxies with op-native quantities :
+
+| Op | Today (M5 proxy) | M7 (real) |
+|---|---|---|
+| replay_rate | `loss_last` (single trainer.fit loss) | distinct-replay rate per `replay_real` (count of unique latent samples emitted / total batches) |
+| downscale_norm | `sample_norm` (single sampler.sample L2) | rank-decay measure from `downscale_real` (S-Vd: top-k singular-value retained ratio post-shrink) |
+| restructure_sum | hard-coded `0.0` | `restructure_real` topology-diff size (Add / Remove / Reroute event counts, S3-guarded) |
+| recombine_rate | `float(len(losses))` | novel-sample rate per `recombine_real` (LatentSample provenance count, ep-tag distinct) |
+| delta_acc | `loss_first - loss_last` | downstream MLP classifier delta accuracy on the task's val split (real CL signal) |
+| wall_time_s | per-cell wall | unchanged |
+
+`delta_acc` becomes a real continual-learning measurement : train a
+tiny one-layer classifier head on the substrate's latents over the
+task, evaluate on the task's val split. This is what makes H1
+(forgetting / replay benefit) actually measurable.
+
+### D3 — Per-profile dispatch
+
+Inside `execute_profile` :
+
+1. Read the activation set from `request.profile_obj` (extend
+   `_CellRequest` to carry the profile dataclass, not just the
+   string tag — keeps lookups out of the substrate).
+2. For each activated op, in the canonical chain order
+   `(replay → downscale → restructure) ∥ recombine` (per
+   `kiki_oniric/dream/operations/CLAUDE.md`), invoke the
+   `_real.py` handler with the substrate state.
+3. Collect the metrics dict, emit it as-is to the harness row.
+
+The synthetic-only branch (no `loader_batches`) is removed in M7 —
+once the substrate respects the profile contract, the synthetic
+path becomes redundant with the conformance tests. The R1 hashes
+for the synthetic path are regenerated under FC MINOR.
+
+### D4 — FC MINOR justification
+
+Framework-C §12 bump rules : a substrate change that ships a *new*
+primitive-activation surface is FC MINOR. M7 ships :
+
+- `mlx_latent_diffusion` ↔ profile-contract binding (new behaviour).
+- 4 new `_real.py` ↔ substrate adapters (mechanical).
+- A new conformance test in `tests/conformance/axioms/test_dr3_diffusion_profile.py`
+  proving the substrate's `execute_profile` activates exactly the
+  primitives the profile declares (no more, no less).
+
+EC stays `+PARTIAL` until the M7 re-bench result is reviewed by
+ship-critic at M6.
+
+### D5 — R1 regeneration
+
+The synthetic R1 entries (`test_r1_diffusion_train_step`,
+`test_r1_diffusion_dream_replay`, `test_r1_diffusion_full_de`) all
+change under M7 because the substrate pipeline changes shape. They
+are regenerated under the M7 FC bump with `status: "pending_review"`
+per `REBASELINE_NOTE.md` discipline. A new entry
+`test_r1_diffusion_profile_activation` is added : same `(seed,
+task_idx)` cell across the 3 profiles produces 3 distinct hashes
+that are *each* byte-stable within a machine.
+
+### D6 — Acceptance for the eventual bench v3
+
+The M7 work is *complete* (and unlocks M6) when :
+
+1. All 4 conformance tests pass : `test_dr3_diffusion_profile.py`
+   (new) + existing `test_dr{0,1,3}_diffusion*.py`.
+2. The 450-cell bench v3 on macM1 produces 450 unique hashes AND
+   per-profile metric distributions are visibly different (e.g.
+   `restructure_sum > 0` for `p_max` only).
+3. At least one of {H1, H2, H4} returns `reject_h0 == True` for
+   at least one profile-vs-baseline pair (positive signal proves
+   the substrate is no longer a degenerate uniform-output).
+4. R1 within-machine byte-stable on macM1 (cold re-run produces
+   identical hashes across all 450 cells).
+
+If #3 fires `False` everywhere (i.e. profile contract honoured but
+no positive verdict), the result is **still** acceptance-worthy : it
+becomes a stronger empirical-emptiness claim, citable in paper 2 §6
+alongside G4-sexto / G4-septimo. M7 ships either way.
+
+## 4. File touch map (M7 implementation plan target)
+
+| File | Action | LoC est. |
+|---|---|---|
+| `kiki_oniric/substrates/mlx_latent_diffusion.py` | Replace `execute_profile` body with per-profile dispatch | +120 −80 |
+| `kiki_oniric/substrates/_diffusion/dream_ops_adapter.py` | New : 4 substrate→`_real.py` adapter shims | +200 |
+| `scripts/ablation_cycle3_diffusion.py` | Extend `_CellRequest` with `profile_obj`, materialise it from the profile string | +30 −5 |
+| `kiki_oniric/profiles/p_{min,equ,max}.py` | Read-only — confirm activation maps match D2 table | 0 |
+| `tests/conformance/axioms/test_dr3_diffusion_profile.py` | New : prove profile→activation surface | +90 |
+| `tests/reproducibility/golden_hashes_apple_*.json` | Regenerate per chip family under FC MINOR | (regen) |
+| `tests/reproducibility/REBASELINE_NOTE.md` | Append M7 rebaseline entry | +10 |
+| `kiki_oniric/substrates/mlx_latent_diffusion.py` (header) | Bump `MLX_LATENT_DIFFUSION_SUBSTRATE_VERSION` to `C-v0.15.0+PARTIAL` | ±1 |
+| `pyproject.toml` | SemVer 0.22.2 → 0.23.0 (FC MINOR) | ±1 |
+| `CHANGELOG.md` | New section `[C-v0.15.0+PARTIAL] — 2026-05-2X` documenting M7 | +15 |
+| `docs/proofs/dr3-diffusion-substrate-evidence.md` | Bump to v1.0 with M7 + bench-v3 evidence | +60 |
+| `docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` | §3.X amendment if profile→activation table is normatively pinned | +20 (or 0 if §3 already pins) |
+
+EN→FR propagation : the framework-C amendment (if any) propagates
+to `docs/specs-fr/`.
+
+## 5. Out of scope for M7
+
+- Paper 2 §7.9 drafting (M6).
+- OSF amendment filing (M6).
+- DualVer flip to `+STABLE` (M6, gated on ship-critic).
+- Cross-machine R1 reseeding (deferred to nightly per existing
+  `docs/proofs/r1-cross-machine.md` posture).
+- Adding new dream-side primitives (M7 only binds the existing 4).
+
+## 6. Risks
+
+| Ref | Risk | Mitigation |
+|---|---|---|
+| R1 | The diffusion-substrate adapters are non-trivial (e.g. `restructure_real` topology-diff doesn't map onto a denoiser MLP without a topology stand-in) | Plan task : decide the diffusion's "topology" surface explicitly (the MLP layer stack is the natural choice). If the mapping is genuinely impossible for restructure on this substrate, document and emit a documented no-op (mirror Canal 4 attention-prior treatment) — that is still a DR-3 conformance fix because the *contract* (substrate declares which ops it supports) is now honoured. |
+| R2 | FC MINOR bump triggers a paper 1 / framework-C spec mirror update in `docs/specs-fr/` | Plan tasks the FR mirror as one task. Per `CONTRIBUTING.md`, EN→FR propagation is enforced in the same PR. |
+| R3 | The 4 R1 hashes change → existing nightly `r1-nightly.yml` fails on first push | Plan ships the regenerated golden hashes in the same PR as the substrate change. The nightly fails for the duration of the PR review window — that is expected per `REBASELINE_NOTE.md` `pending_review` discipline. |
+| R4 | M7 takes longer than 5 days | Fall back to the sequencing-spec §4 recovery : ship M6 as `+PARTIAL` with the existing 2026-05-21 milestone, file the hedged OSF amendment, M7 → Wave 3c. |
+
+## 7. Self-review
+
+- **Placeholder scan** : no TBD ; `2026-05-2X` is the deliberately
+  unresolved re-bench date.
+- **Internal consistency** : D2 metric table ↔ D6 acceptance ↔ §4
+  touch map all reference the same 4 ops.
+- **Scope check** : single substrate, single conformance gap, single
+  FC MINOR bump. Fits one writing-plans plan.
+- **Ambiguity** : the activation map in §2 is *illustrative* —
+  the implementation plan will read the real dataclasses. Flagged
+  explicitly so the plan task starts with a read of
+  `kiki_oniric/profiles/p_{min,equ,max}.py`.

--- a/docs/superpowers/specs/2026-05-21-m7-substrate-dr3-design.md
+++ b/docs/superpowers/specs/2026-05-21-m7-substrate-dr3-design.md
@@ -18,26 +18,59 @@ H4 verdicts — `reject_h0 == True` exactly where the framework predicts,
 and `False` exactly where it predicts the empirical-emptiness pattern
 (DR-4 v0.6 amendment, paper 2 §6).
 
-## 2. The contract (framework C §3, kiki_oniric/profiles/)
+## 2. The contract (framework C §3.1, NORMATIVE)
 
-The three profiles activate the dream-side primitives as follows
-(verbatim from `kiki_oniric/profiles/p_min.py`, `p_equ.py`,
-`p_max.py` — confirm against disk at plan time) :
+**Corrected post-audit 2026-05-21.** The activation table is fixed by
+`docs/specs/2026-04-17-dreamofkiki-framework-C-design.md` §3.1 as a
+formal definition with the monotonic inclusion constraint of §3.2 :
+`ops(P_min) ⊆ ops(P_equ) ⊆ ops(P_max)`. The substrate **must** honour
+this exact shape — the table is normative, not illustrative.
 
-| Profile | Replay (α) | Downscale (β) | Restructure (γ) | Recombine (δ) |
+| Profile | replay | downscale | restructure | recombine |
 |---|---|---|---|---|
-| `p_min` | — | — | — | ✓ |
-| `p_equ` | ✓ | ✓ | — | ✓ |
-| `p_max` | ✓ | ✓ | ✓ | ✓ |
+| `p_min` | ✓ | ✓ | — | — |
+| `p_equ` | ✓ | ✓ | ✓ | ✓ (light) |
+| `p_max` | ✓ | ✓ | ✓ | ✓ (full) |
 
-(Mapping is illustrative — M7 plan reads the real profile dataclasses
-from `kiki_oniric/profiles/` and binds the substrate to them ; if the
-disk shape diverges from this table, the disk wins.)
+(Plus channel-out sets : P_min → {WeightDelta}, P_equ → {WeightDelta,
+HierarchyChange, AttentionPrior}, P_max → all 4. M7 honours the ops
+column ; channels are surfaced through the existing channel infra and
+are out of scope for the substrate adapter.)
+
+`PMinProfile` / `PEquProfile` / `PMaxProfile` already encode this map
+**in their `__post_init__`** — each registers exactly the listed
+handlers on `self.runtime: DreamRuntime`. The handler signatures
+(audited 2026-05-21) :
+
+- `replay_real_handler(state: ReplayRealState, *, model, lr=0.01)`
+  → `Callable[[DreamEpisode], None]`. Reads `input_slice["beta_records"]`.
+  Mutates `model.parameters()` in-place ; touches K1
+  `state.last_compute_flops` / `total_compute_flops`.
+- `downscale_real_handler(state: DownscaleRealState, *, model)` →
+  `Callable[[DreamEpisode], None]`. Reads `input_slice["shrink_factor"]`
+  (must be in `(0, 1]`). Mutates layer weights + bias in-place ; S2
+  finite guard on the mutated tensors. K1 = `_param_count(model)`.
+- `restructure_real_handler(state: RestructureRealState, *, model)`
+  → `Callable[[DreamEpisode], None]`. *Legacy cycle-3* — only
+  `topo_op == "reroute"` is supported in the **real** variant
+  (the `_lora` variant has the full `{add, remove, reroute}` vocab).
+  Reads `input_slice["topo_op"]` and `input_slice["swap_indices"]`.
+- `recombine_real_handler(state: RecombineRealState, *, encoder, decoder, seed)`
+  → `Callable[[DreamEpisode], LatentSample | None]`. Reads
+  `input_slice["delta_latents"]` (required, non-empty — raises
+  `I3` on empty). The substrate must supply VAE-shape `encoder` /
+  `decoder` ; the diffusion `MLPDenoiser` is **not** a VAE — see §3
+  decision D7 below for how the substrate maps onto this.
 
 `mlx_latent_diffusion` today runs `Trainer(denoiser).fit + Sampler.sample`
-unconditionally and attaches the profile string to the output dict. M7
-replaces this with a per-profile pipeline that calls the real handler
-for each activated primitive.
+unconditionally, attaches the profile string to the output dict, and
+**never instantiates `PMinProfile / PEquProfile / PMaxProfile`** —
+the `DreamRuntime` handler-dispatch mechanism is entirely bypassed
+(`scripts/ablation_cycle3_diffusion.py` carries only the profile
+**string** in `_CellRequest`, never the dataclass). M7 replaces this
+with a per-profile pipeline that *instantiates* the right profile
+dataclass, drives a small `DreamEpisode` stream through its `runtime`,
+and reads the per-op metrics off the profile's state fields.
 
 ## 3. Decisions
 
@@ -52,41 +85,95 @@ for each activated primitive.
   denoiser / encoder / sampler handles), and reads back the
   state's emitted metric.
 
-### D2 — Per-op metrics
+### D2 — Per-op metrics (audited)
 
-Replace the M5-era proxies with op-native quantities :
+Read the metrics off the **state objects the handlers already mutate**.
+The four state classes from the audit (verbatim) :
 
-| Op | Today (M5 proxy) | M7 (real) |
-|---|---|---|
-| replay_rate | `loss_last` (single trainer.fit loss) | distinct-replay rate per `replay_real` (count of unique latent samples emitted / total batches) |
-| downscale_norm | `sample_norm` (single sampler.sample L2) | rank-decay measure from `downscale_real` (S-Vd: top-k singular-value retained ratio post-shrink) |
-| restructure_sum | hard-coded `0.0` | `restructure_real` topology-diff size (Add / Remove / Reroute event counts, S3-guarded) |
-| recombine_rate | `float(len(losses))` | novel-sample rate per `recombine_real` (LatentSample provenance count, ep-tag distinct) |
-| delta_acc | `loss_first - loss_last` | downstream MLP classifier delta accuracy on the task's val split (real CL signal) |
-| wall_time_s | per-cell wall | unchanged |
+```python
+@dataclass class ReplayRealState:
+    total_records_consumed: int = 0
+    last_loss: float | None = None
+    last_compute_flops: int = 0
+    total_compute_flops: int = 0
 
-`delta_acc` becomes a real continual-learning measurement : train a
-tiny one-layer classifier head on the substrate's latents over the
-task, evaluate on the task's val split. This is what makes H1
-(forgetting / replay benefit) actually measurable.
+@dataclass class DownscaleRealState:
+    compound_factor: float = 1.0
+    last_compute_flops: int = 0
 
-### D3 — Per-profile dispatch
+@dataclass class RestructureRealState:
+    diff_history: list[str] = field(default_factory=list)
+    last_compute_flops: int = 0
+    adds_this_episode: int = 0
+    total_adds: int = 0
+    total_removes: int = 0
+    total_reroutes: int = 0
+
+@dataclass class RecombineRealState:
+    last_sample: list | None = None
+    last_compute_flops: int = 0
+    _episode_count: int = 0
+```
+
+Substrate row schema after M7 (replaces the M5 proxies — the field
+names stay so milestone-aggregator code does not break, but the
+**source** of each field changes) :
+
+| Substrate row field | Source after M7 |
+|---|---|
+| `replay_rate` | `replay_state.last_loss` (drops to `0.0` if replay inactive) |
+| `downscale_norm` | `downscale_state.compound_factor` (stays `1.0` if inactive — that *is* "no downscaling") |
+| `restructure_sum` | `restructure_state.total_reroutes` (legacy real-handler only emits `reroute`, see audit ; stays `0` if inactive — matching the M5 behaviour for `p_min` honestly) |
+| `recombine_rate` | `recombine_state._episode_count` (number of recombine events ; `0` if inactive) |
+| `delta_acc` | a tiny 1-layer classifier head trained on the substrate's latents over the task, eval on the task's val split — task-local CL accuracy delta (`acc_after_dream − acc_before_dream`). This is the real H1 signal. |
+| `wall_time_s` | per-cell wall, unchanged |
+| `op_flops_total` | new : sum of `last_compute_flops` across the activated ops (K1 audit trail) |
+
+`delta_acc` is the load-bearing new measurement. The classifier head
+is a `mx.nn.Linear(d_latent, N_CLASSES_PER_TASK)` trained for a
+fixed micro-budget (e.g. 50 steps, batch 64) on the encoded latents
+before and after the dream cycle ; the difference is per-cell real
+CL signal. Hyper-parameters pinned in the plan so the bench is
+deterministic.
+
+### D3 — Per-profile dispatch via existing `DreamRuntime`
 
 Inside `execute_profile` :
 
-1. Read the activation set from `request.profile_obj` (extend
-   `_CellRequest` to carry the profile dataclass, not just the
-   string tag — keeps lookups out of the substrate).
-2. For each activated op, in the canonical chain order
-   `(replay → downscale → restructure) ∥ recombine` (per
-   `kiki_oniric/dream/operations/CLAUDE.md`), invoke the
-   `_real.py` handler with the substrate state.
-3. Collect the metrics dict, emit it as-is to the harness row.
+1. **Instantiate the profile dataclass** matching `request.profile`
+   (`{"p_min": PMinProfile, "p_equ": PEquProfile, "p_max": PMaxProfile}[…]`).
+   Each profile's `__post_init__` already registers exactly the right
+   handlers on its `runtime: DreamRuntime` per framework-C §3.1 — we
+   do **not** re-derive the activation surface, we *use* it.
+2. The substrate provides : the `model` (denoiser MLP), and for the
+   `recombine` adapter an `encoder` / `decoder` pair (see D7) and a
+   `seed`. These are passed to the handler factories via a small
+   **substrate-wiring adapter** that re-registers the existing
+   handlers on the profile's `runtime` with the substrate-supplied
+   `model` argument (the default `model=None` in profile fields
+   needs to be replaced for the real path).
+3. Drive a **canonical `DreamEpisode` stream** : one `DreamEpisode`
+   per loader batch, with `input_slice` populated for *all* possible
+   ops (the runtime ignores keys whose op isn't registered, so a
+   single shared episode shape works) :
+   - `"beta_records"` : encoded `(x, y)` pairs from the batch
+   - `"shrink_factor"` : a fixed value (e.g. `0.95`) so the
+     downscale handler does measurable but bounded work
+   - `"topo_op"` : `"reroute"` ; `"swap_indices"` : a deterministic
+     pair per (seed, batch_idx)
+   - `"delta_latents"` : the encoder output for the batch
+   - `"species"` : `"diffusion"`
+4. Read the metrics dict by snapshotting the 4 state dataclasses
+   after the run. Inactive ops keep their default values (legitimate
+   zeros, **not** hard-coded — the field defaults *are* the framework-C
+   no-op semantics).
+5. Compute `delta_acc` separately (before/after head-eval, see D2).
 
-The synthetic-only branch (no `loader_batches`) is removed in M7 —
-once the substrate respects the profile contract, the synthetic
-path becomes redundant with the conformance tests. The R1 hashes
-for the synthetic path are regenerated under FC MINOR.
+The synthetic-only branch (no `loader_batches`) **stays** in M7 to
+preserve the M3 R1 test contract — the synthetic path remains
+profile-aware in the same way, but with synthetic latents instead
+of CIFAR. The synthetic-path R1 hashes regenerate under FC MINOR
+(D5).
 
 ### D4 — FC MINOR justification
 
@@ -113,6 +200,32 @@ per `REBASELINE_NOTE.md` discipline. A new entry
 task_idx)` cell across the 3 profiles produces 3 distinct hashes
 that are *each* byte-stable within a machine.
 
+### D7 — VAE-shape adapter for the recombine handler
+
+The `recombine_real_handler` audit reveals that it expects an
+`encoder: VAEEncoder` and a `decoder: VAEDecoder` per the existing
+Protocols at `kiki_oniric/dream/operations/recombine_real.py` lines
+55-77 (audit-confirmed). The diffusion substrate has an encoder
+(`self._cifar_encoder : 3072 → d_latent`) but **no decoder** — the
+`MLPDenoiser` predicts noise, it does not reconstruct features.
+
+For the recombine contract to be honoured on the diffusion substrate
+(active for `p_equ` and `p_max` per framework-C §3.1), M7 adds a
+small **`_diffusion_decoder` MLP** mirroring the existing `Encoder`
+shape : `d_latent → RAW_FEATURE_DIM=3072`. Construction lives in
+the substrate's `__init__` next to `_cifar_encoder` ; the two are
+passed as `encoder` / `decoder` arguments to `recombine_real_handler`
+at handler-build time.
+
+This is **not** a learned-decoder claim — it is a random-init MLP
+that gives the recombine handler a Protocol-valid surface so the
+deterministic LatentSample generation is well-defined. The decoder
+weights are stable across the bench (init once, reuse 450 cells per
+seed family — actually re-init per cell to match the per-cell
+fresh-substrate posture from M5).
+
+`p_min` is unaffected — recombine is inactive there.
+
 ### D6 — Acceptance for the eventual bench v3
 
 The M7 work is *complete* (and unlocks M6) when :
@@ -138,9 +251,12 @@ alongside G4-sexto / G4-septimo. M7 ships either way.
 | File | Action | LoC est. |
 |---|---|---|
 | `kiki_oniric/substrates/mlx_latent_diffusion.py` | Replace `execute_profile` body with per-profile dispatch | +120 −80 |
-| `kiki_oniric/substrates/_diffusion/dream_ops_adapter.py` | New : 4 substrate→`_real.py` adapter shims | +200 |
-| `scripts/ablation_cycle3_diffusion.py` | Extend `_CellRequest` with `profile_obj`, materialise it from the profile string | +30 −5 |
-| `kiki_oniric/profiles/p_{min,equ,max}.py` | Read-only — confirm activation maps match D2 table | 0 |
+| `kiki_oniric/substrates/_diffusion/dream_ops_adapter.py` | New : profile → substrate-wiring adapter that supplies `model` / `encoder` / `decoder` / `seed` to the existing `_real.py` factories and re-registers them on the profile's `runtime` | +150 |
+| `kiki_oniric/substrates/_diffusion/decoder.py` | New : random-init MLP `d_latent → 3072` for the recombine VAE-shape contract (D7) | +40 |
+| `kiki_oniric/substrates/_diffusion/__init__.py` | Re-export the new `Decoder` next to `Encoder` | +2 |
+| `scripts/ablation_cycle3_diffusion.py` | No `profile_obj` field needed — the substrate instantiates `PMinProfile/PEquProfile/PMaxProfile` from the string at `execute_profile` entry. Keep `_CellRequest` shape stable. | 0 |
+| `kiki_oniric/profiles/p_{min,equ,max}.py` | Read-only — the existing `__post_init__` handler registrations *are* the activation surface ; M7 honours them via D3 | 0 |
+| `kiki_oniric/substrates/_diffusion/cl_eval_head.py` | New : 1-layer classifier head for `delta_acc` measurement (D2) | +60 |
 | `tests/conformance/axioms/test_dr3_diffusion_profile.py` | New : prove profile→activation surface | +90 |
 | `tests/reproducibility/golden_hashes_apple_*.json` | Regenerate per chip family under FC MINOR | (regen) |
 | `tests/reproducibility/REBASELINE_NOTE.md` | Append M7 rebaseline entry | +10 |
@@ -166,7 +282,7 @@ to `docs/specs-fr/`.
 
 | Ref | Risk | Mitigation |
 |---|---|---|
-| R1 | The diffusion-substrate adapters are non-trivial (e.g. `restructure_real` topology-diff doesn't map onto a denoiser MLP without a topology stand-in) | Plan task : decide the diffusion's "topology" surface explicitly (the MLP layer stack is the natural choice). If the mapping is genuinely impossible for restructure on this substrate, document and emit a documented no-op (mirror Canal 4 attention-prior treatment) — that is still a DR-3 conformance fix because the *contract* (substrate declares which ops it supports) is now honoured. |
+| R1 | The diffusion-substrate adapters are non-trivial (e.g. `restructure_real` only supports `reroute` per audit — the *legacy* real handler is feature-restricted vs. the LoRA variant) | The denoiser MLP `n_layers` stack *is* the topology surface for `reroute` (swap two layer indices). For the `add` and `remove` topo_ops the handler raises today — that is a substrate-honest limitation, not an M7 blocker. The activation surface honours what each profile actually drives ; the diffusion's restructure surface is `{reroute}` and the M7 conformance test asserts exactly that. |
 | R2 | FC MINOR bump triggers a paper 1 / framework-C spec mirror update in `docs/specs-fr/` | Plan tasks the FR mirror as one task. Per `CONTRIBUTING.md`, EN→FR propagation is enforced in the same PR. |
 | R3 | The 4 R1 hashes change → existing nightly `r1-nightly.yml` fails on first push | Plan ships the regenerated golden hashes in the same PR as the substrate change. The nightly fails for the duration of the PR review window — that is expected per `REBASELINE_NOTE.md` `pending_review` discipline. |
 | R4 | M7 takes longer than 5 days | Fall back to the sequencing-spec §4 recovery : ship M6 as `+PARTIAL` with the existing 2026-05-21 milestone, file the hedged OSF amendment, M7 → Wave 3c. |


### PR DESCRIPTION
Three companion specs closing the Wave 3b roadmap after M5 shipped (PR #35):

- **Sequencing decision**: M7 (substrate DR-3 fix for issue #36) runs first, then M6 (paper section 7.9 + OSF amendment + DualVer flip). Rationale: the OSF amendment DOI is permanent; ship the substrate-complete story rather than file a hedged +PARTIAL amendment that would need amending again next week. Recovery posture: if M7 stalls past day 5, fall back to M6 +PARTIAL with the existing 2026-05-21 milestone.

- **M7 spec**: framework-C profile contract honoured by execute_profile (per-profile primitive activation dispatch). FC MINOR bump. 4 dream-side _real.py adapter shims. New conformance test asserting the profile-activation surface. Re-bench produces non-degenerate verdicts.

- **M6 spec**: paper 2 section 7.9 (EN + FR), DR-3 evidence v1.0, OSF amendment Q6JYN-W3B published with DataCite DOI, ship-critic gate, DualVer flip mechanically gated by framework-C section 12.3.

Two PR gates: (1) user reviews the 3 specs and approves the sequence, (2) writing-plans skill then produces the M7 plan first, M6 plan after. No code lands until the plans are reviewed in turn.